### PR TITLE
not a good idea to add more than 1 replica, jellyfin uses sqllite and…

### DIFF
--- a/apps/media/jellyfin/deployment.yaml
+++ b/apps/media/jellyfin/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   strategy:
     type: RollingUpdate
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: jellyfin

--- a/apps/media/jellyfin/values.yaml
+++ b/apps/media/jellyfin/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 # -- Number of Jellyfin replicas to start. Should be left at 1.
-replicaCount: 2
+replicaCount: 1
 
 # -- Image pull secrets to authenticate with private repositories.
 # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
… the app isnt built for protecting against multiple pods writing to one common localdb