### PR TITLE
feat: add Dask Kubernetes Operator and science namespace

### DIFF
--- a/apps/science/application.yaml
+++ b/apps/science/application.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dask-kubernetes-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mithr4ndir/k8s-argocd.git
+    targetRevision: HEAD
+    path: apps/science/dask-operator
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: science
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/science/dask-autoscaler.yaml
+++ b/apps/science/dask-autoscaler.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kubernetes.dask.org/v1
+kind: DaskAutoscaler
+metadata:
+  name: lsdb-autoscaler
+  namespace: science
+spec:
+  cluster: lsdb-cluster
+  minimum: 1
+  maximum: 6

--- a/apps/science/dask-cluster.yaml
+++ b/apps/science/dask-cluster.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: kubernetes.dask.org/v1
+kind: DaskCluster
+metadata:
+  name: lsdb-cluster
+  namespace: science
+spec:
+  worker:
+    replicas: 1
+    spec:
+      containers:
+        - name: worker
+          image: ghcr.io/cwladino/lsdb-dask:latest
+          args:
+            - dask-worker
+            - --name
+            - $(DASK_WORKER_NAME)
+            - --dashboard
+            - --dashboard-address
+            - "8788"
+          ports:
+            - name: http-dashboard
+              containerPort: 8788
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          env:
+            - name: DASK_WORKER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: hats-catalogs
+              mountPath: /data/catalogs
+      volumes:
+        - name: hats-catalogs
+          persistentVolumeClaim:
+            claimName: hats-catalogs
+  scheduler:
+    spec:
+      containers:
+        - name: scheduler
+          image: ghcr.io/cwladino/lsdb-dask:latest
+          args:
+            - dask-scheduler
+          ports:
+            - name: tcp-comm
+              containerPort: 8786
+              protocol: TCP
+            - name: http-dashboard
+              containerPort: 8787
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "2"
+              memory: 6Gi
+            limits:
+              cpu: "2"
+              memory: 6Gi
+          volumeMounts:
+            - name: hats-catalogs
+              mountPath: /data/catalogs
+      volumes:
+        - name: hats-catalogs
+          persistentVolumeClaim:
+            claimName: hats-catalogs
+    service:
+      type: ClusterIP
+      selector:
+        dask.org/cluster-name: lsdb-cluster
+        dask.org/component: scheduler
+      ports:
+        - name: tcp-comm
+          port: 8786
+          targetPort: tcp-comm
+          protocol: TCP
+        - name: http-dashboard
+          port: 8787
+          targetPort: http-dashboard
+          protocol: TCP

--- a/apps/science/dask-operator/Chart.lock
+++ b/apps/science/dask-operator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: dask-kubernetes-operator
+  repository: https://helm.dask.org
+  version: 2026.3.0
+digest: sha256:511327a26df74dd9b3314658614b8d214e656ad1cf49de735ae9fcc77c967cb9
+generated: "2026-04-06T01:01:50.15015485Z"

--- a/apps/science/dask-operator/Chart.yaml
+++ b/apps/science/dask-operator/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: dask-kubernetes-operator
+version: 1.0.0
+description: Dask Kubernetes Operator for distributed computing
+dependencies:
+  - name: dask-kubernetes-operator
+    version: "2026.3.0"
+    repository: https://helm.dask.org

--- a/apps/science/dask-operator/values.yaml
+++ b/apps/science/dask-operator/values.yaml
@@ -1,0 +1,20 @@
+dask-kubernetes-operator:
+  rbac:
+    cluster: true
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  kopfArgs:
+    - --namespace=science

--- a/apps/science/hats-catalogs-pvc.yaml
+++ b/apps/science/hats-catalogs-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hats-catalogs
+  namespace: science
+  labels:
+    app: science
+spec:
+  storageClassName: k8s-nfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/science/ingress.yaml
+++ b/apps/science/ingress.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dask-dashboard
+  namespace: science
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/connection-proxy-header: "keep-alive"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: dask.quasarlab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lsdb-cluster-scheduler
+                port:
+                  number: 8787

--- a/apps/science/kustomization.yaml
+++ b/apps/science/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - namespace.yaml
+  - resource-quota.yaml
+  - application.yaml
+  - hats-catalogs-pvc.yaml
+  - dask-cluster.yaml
+  - dask-autoscaler.yaml
+  - ingress.yaml

--- a/apps/science/namespace.yaml
+++ b/apps/science/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: science
+  labels:
+    name: science

--- a/apps/science/resource-quota.yaml
+++ b/apps/science/resource-quota.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: science-quota
+  namespace: science
+spec:
+  hard:
+    limits.cpu: "18"
+    limits.memory: 36Gi
+    requests.cpu: "18"
+    requests.memory: 36Gi

--- a/environments/dev/kustomization.yaml
+++ b/environments/dev/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ../../infrastructure/security
   - ../../apps/media
   - ../../apps/dashboard
+  - ../../apps/science


### PR DESCRIPTION
Deploy Dask Kubernetes Operator via ArgoCD with:
- science namespace with ResourceQuota (18 CPU, 36Gi)
- DaskCluster CR (scheduler + workers) for lsdb workloads
- DaskAutoscaler (min 1, max 6 workers)
- NFS PVC (50Gi) for HATS astronomical catalog storage
- Ingress for Dask dashboard at dask.quasarlab.local