### PR TITLE
fix: AlertManager HA with 2 replicas, PDB, and notification drop alert

### DIFF
--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -60,7 +60,12 @@ kube-prometheus-stack:
   alertmanager:
     enabled: true
     alertmanagerSpec:
+      replicas: 2
       configSecret: alertmanager-custom-config
+      podAntiAffinity: "soft"
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
       storage:
         volumeClaimTemplate:
           spec:
@@ -225,6 +230,14 @@ kube-prometheus-stack:
               annotations:
                 summary: "Prometheus rule evaluation failures"
                 description: "Prometheus is failing to evaluate alerting/recording rules."
+            - alert: PrometheusNotificationsDropped
+              expr: rate(prometheus_notifications_dropped_total[5m]) > 0
+              for: 5m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Prometheus is dropping notifications to AlertManager"
+                description: "Prometheus has been dropping alert notifications for 5 minutes. AlertManager may be unreachable. Current rate: {{ $value | printf \"%.2f\" }}/s."
     proxmox-alerts:
       groups:
         - name: proxmox-availability


### PR DESCRIPTION
Scale AlertManager to 2 replicas with soft pod anti-affinity to prevent single-replica SPOF. Adds PodDisruptionBudget (minAvailable: 1) and a PrometheusNotificationsDropped alert rule for when Prometheus cannot reach AlertManager.

Root cause: k8cluster2 hard crash on 2026-04-05 caused 6h10m silent alerting failure with 6,770 dropped notifications.