### PR TITLE
Deploy sky-explorer to science namespace

### DIFF
--- a/apps/science/kustomization.yaml
+++ b/apps/science/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
   - servicemonitor.yaml
   - prometheus-rules.yaml
   - grafana-dashboard.yaml
+  - sky-explorer/deployment.yaml
+  - sky-explorer/service.yaml
+  - sky-explorer/ingress.yaml

--- a/apps/science/sky-explorer/deployment.yaml
+++ b/apps/science/sky-explorer/deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sky-explorer
+  namespace: science
+  labels:
+    app: sky-explorer
+  annotations:
+    argocd.argoproj.io/sync-wave: '3'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sky-explorer
+  template:
+    metadata:
+      labels:
+        app: sky-explorer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: sky-explorer
+          image: ghcr.io/mithr4ndir/sky-explorer:latest
+          ports:
+            - name: http
+              containerPort: 8050
+              protocol: TCP
+          env:
+            - name: GAIA_CATALOG_URL
+              value: "https://data.lsdb.io/hats/gaia_dr3/gaia"
+            - name: DASK_SCHEDULER
+              value: "lsdb-cluster-scheduler.science.svc.cluster.local:8786"
+            - name: MAX_RESULTS
+              value: "50000"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/apps/science/sky-explorer/ingress.yaml
+++ b/apps/science/sky-explorer/ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sky-explorer
+  namespace: science
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-body-size: '10m'
+    argocd.argoproj.io/sync-wave: '3'
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: sky.quasarlab.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: sky-explorer
+                port:
+                  number: 8050

--- a/apps/science/sky-explorer/service.yaml
+++ b/apps/science/sky-explorer/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sky-explorer
+  namespace: science
+  labels:
+    app: sky-explorer
+  annotations:
+    argocd.argoproj.io/sync-wave: '3'
+spec:
+  type: ClusterIP
+  selector:
+    app: sky-explorer
+  ports:
+    - name: http
+      port: 8050
+      targetPort: http
+      protocol: TCP

--- a/apps/science/sky-explorer/service.yaml
+++ b/apps/science/sky-explorer/service.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app: sky-explorer
   annotations:
-    argocd.argoproj.io/sync-wave: '3'
+    argocd.argoproj.io/sync-wave: "3"
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   selector:
     app: sky-explorer
   ports:


### PR DESCRIPTION
## Summary
- Adds Plotly Dash + lsdb web app for interactive Gaia DR3 catalog exploration
- Deployment (1 replica, 2Gi-4Gi memory) with health checks
- ClusterIP Service + Ingress at sky.quasarlab.local
- Connects to existing Dask scheduler for distributed queries

## Manifests
- apps/science/sky-explorer/deployment.yaml
- apps/science/sky-explorer/service.yaml
- apps/science/sky-explorer/ingress.yaml
- Updated kustomization.yaml with new resources

## Container
- Image: ghcr.io/mithr4ndir/sky-explorer:latest
- Source: https://github.com/mithr4ndir/sky-explorer

## Test plan
- [ ] Verify ArgoCD syncs the new resources
- [ ] Confirm pod reaches Running state
- [ ] Test sky.quasarlab.local resolves and loads the Dash UI
- [ ] Run a cone search (Pleiades preset) and verify results render
- [ ] Confirm Dask connection status shows connected with workers