### PR TITLE
fix(monitoring): wire Watchdog to Healthchecks.io and HA the discord alert proxy

### DIFF
--- a/infrastructure/monitoring/alertmanager-config.yaml
+++ b/infrastructure/monitoring/alertmanager-config.yaml
@@ -35,7 +35,10 @@ stringData:
       routes:
         - matchers:
             - alertname = "Watchdog"
-          receiver: "null"
+          receiver: healthchecks
+          group_wait: 0s
+          group_interval: 1m
+          repeat_interval: 2m
         - matchers:
             - alertname =~ "InfoInhibitor|KubeVersionMismatch"
           receiver: "null"
@@ -84,3 +87,8 @@ stringData:
         webhook_configs:
           - send_resolved: true
             url: "http://discord-alert-proxy.monitoring.svc:9095/webhook"
+      - name: healthchecks
+        webhook_configs:
+          - send_resolved: false
+            url_file: /etc/alertmanager/secrets/healthchecks-watchdog/url
+            max_alerts: 0

--- a/infrastructure/monitoring/discord-alert-proxy/deployment.yaml
+++ b/infrastructure/monitoring/discord-alert-proxy/deployment.yaml
@@ -7,10 +7,15 @@ metadata:
   labels:
     app: discord-alert-proxy
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: discord-alert-proxy
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -18,6 +23,22 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: discord-alert-proxy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: discord-alert-proxy
       containers:
         - name: proxy
           image: python:3.12-slim

--- a/infrastructure/monitoring/discord-alert-proxy/kustomization.yaml
+++ b/infrastructure/monitoring/discord-alert-proxy/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - externalsecret.yaml
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/infrastructure/monitoring/discord-alert-proxy/pdb.yaml
+++ b/infrastructure/monitoring/discord-alert-proxy/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: discord-alert-proxy
+  namespace: monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: discord-alert-proxy

--- a/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
+++ b/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: healthchecks-watchdog
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-infrastructure
+    kind: ClusterSecretStore
+  target:
+    name: healthchecks-watchdog
+    creationPolicy: Owner
+  data:
+    - secretKey: url
+      remoteRef:
+        key: "REPLACE_WITH_1P_ITEM_ID/credential"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -138,6 +138,8 @@ kube-prometheus-stack:
     alertmanagerSpec:
       replicas: 2
       configSecret: alertmanager-custom-config
+      secrets:
+        - healthchecks-watchdog
       podAntiAffinity: "soft"
       podDisruptionBudget:
         enabled: true

--- a/infrastructure/monitoring/kustomization.yaml
+++ b/infrastructure/monitoring/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - loki-external-svc.yaml
   - vector-aggregator-svc.yaml
   - grafana-externalsecret.yaml
+  - healthchecks-watchdog-externalsecret.yaml
   - grafana-dashboards
   - discord-alert-proxy


### PR DESCRIPTION
## Summary

Closes the alerting gap surfaced during the 2026-04-13 pve outage where four VMs (100, 104, 110, 111) stayed offline for ~9 hours with no alert delivered. Two independent failures compounded:

1. The `Watchdog` alert was routed to the `null` receiver, so no external dead man's switch ever fired.
2. `discord-alert-proxy` ran as a single replica on k8cluster1, one of the down VMs. With 2 of 3 K8s control plane nodes offline, the pod could not be rescheduled, and AlertManager's webhook POSTs silently failed.

Root cause of the VM outage itself (freenas-proxmox plugin startup race) will be addressed in a separate PR against ansible-quasarlab.

## Changes

### Watchdog to Healthchecks.io

- New `healthchecks-watchdog` ExternalSecret pulling from 1Password. The item ID is a placeholder (`REPLACE_WITH_1P_ITEM_ID`) that must be filled in after the 1P item exists.
- Mount the resulting Secret into AlertManager via `alertmanagerSpec.secrets`, so the ping URL is never committed to git.
- New `healthchecks` webhook receiver using `url_file` (reads from `/etc/alertmanager/secrets/healthchecks-watchdog/url`).
- Rerouted the `Watchdog` alert from `null` to `healthchecks`. `repeat_interval: 2m` keeps HC.io fed well under the 1h grace window.

### discord-alert-proxy HA

- 1 replica to 2.
- Soft `podAntiAffinity` + `topologySpreadConstraints` across hostnames so replicas prefer different K8s nodes.
- `RollingUpdate` strategy with `maxUnavailable: 0` so at least one pod is always serving.
- New `PodDisruptionBudget` with `minAvailable: 1`, mirroring the AlertManager HA pattern.

## Follow-up required (not in this PR)

- [ ] Create 1Password item in `Infrastructure` vault holding the HC.io ping URL, then replace `REPLACE_WITH_1P_ITEM_ID` in `infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml`.
- [ ] Toggle email notification ON in the HC.io check (currently OFF, which is why the 9h outage also produced no email).
- [ ] Separate PR: fix freenas-proxmox plugin race in `ansible-quasarlab` so VMs come up after reboot.
- [ ] Separate PR or follow-up: add `no-alert` / `maintenance` tag filtering on the `PveGuestDown` rule.

## Test plan

- [ ] kustomize build of `infrastructure/monitoring/` succeeds (verified locally).
- [ ] After merge, ArgoCD applies without error and the ExternalSecret enters `SecretSyncedError` until the 1P item is populated (expected).
- [ ] Once the 1P item exists, confirm `kubectl get secret -n monitoring healthchecks-watchdog -o jsonpath='{.data.url}' | base64 -d` returns the URL with no trailing newline. If trailing newline appears, switch ExternalSecret to a template that strips it.
- [ ] Confirm both alertmanager pods mount the secret at `/etc/alertmanager/secrets/healthchecks-watchdog/url`.
- [ ] Confirm HC.io dashboard starts receiving pings within 2 minutes.
- [ ] Force-drain k8cluster1 node, confirm the second discord-alert-proxy pod on another node continues serving and alerts still reach Discord.
- [ ] Confirm HC.io email notification is enabled and test by pausing pings for >1h.