### PR TITLE
fix(monitoring): set real 1Password item ID for HC.io watchdog

### DIFF
--- a/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
+++ b/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
   data:
     - secretKey: url
       remoteRef:
-        key: "REPLACE_WITH_1P_ITEM_ID/credential"
+        key: "zr7mrafo64zpf7usc2ah5nso2a/credential"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None


### PR DESCRIPTION
Follow-up to #115. That PR merged with the `REPLACE_WITH_1P_ITEM_ID` placeholder still in the ExternalSecret. The 1P item now exists (`Healthchecks.io Watchdog - Alertmanager` in the `Infrastructure` vault, ID `zr7mrafo64zpf7usc2ah5nso2a`), so this PR wires the real ID in.

## Test plan
- [ ] After merge + ArgoCD sync, `kubectl get externalsecret -n monitoring healthchecks-watchdog` shows `SecretSynced=True`
- [ ] `kubectl get secret -n monitoring healthchecks-watchdog -o jsonpath='{.data.url}' | base64 -d` returns the HC.io ping URL
- [ ] HC.io dashboard starts receiving pings within ~2 min
- [ ] Toggle email notification ON in the HC.io check (still OFF per earlier screenshot)