### PR TITLE
feat(monitoring): silence PveGuestDown via no-alert and maintenance tags

### DIFF
--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -335,13 +335,24 @@ kube-prometheus-stack:
                   and on(id, instance)
                   (pve_onboot_status{job="proxmox"} == 1)
                 )
-                * on(id, instance) group_left(name, node)
-                (pve_guest_info{job="proxmox", template="0"})
+                * on(id, instance) group_left(name, node, tags)
+                (pve_guest_info{job="proxmox", template="0", tags!~".*(no-alert|maintenance).*"})
               for: 5m
               labels:
                 severity: warning
               annotations:
                 summary: "{{ $labels.name }} ({{ $labels.id }})"
+                description: |
+                  VM {{ $labels.name }} ({{ $labels.id }}) on {{ $labels.node }} has onboot=1 but is not running. Tag the VM with 'no-alert' (permanent) or 'maintenance' (temporary) in Proxmox to silence this alert.
+            - alert: PveGuestMaintenanceTagStale
+              expr: |
+                pve_guest_info{job="proxmox", template="0", tags=~".*maintenance.*"}
+              for: 24h
+              labels:
+                severity: info
+              annotations:
+                summary: "{{ $labels.name }} still tagged 'maintenance' after 24h"
+                description: "VM {{ $labels.name }} ({{ $labels.id }}) on {{ $labels.node }} has been tagged 'maintenance' for over 24 hours. Remove the tag if the maintenance window is over, otherwise this VM is silently excluded from PveGuestDown alerts."
             - alert: PveQuorumDegraded
               expr: pve_cluster_quorum_total_votes{job="vm-node-exporter"} < pve_cluster_quorum_expected_votes{job="vm-node-exporter"}
               for: 2m


### PR DESCRIPTION
## Summary

Adds a tag-based opt-out for the \`PveGuestDown\` alert so an admin can intentionally stop a VM (testing, decommissioning a service, planned maintenance) without paging. Closes the loose end identified during the 2026-04-13 incident review.

## How it works

1. Tag the VM in Proxmox with one of the reserved tag names:
   - \`no-alert\` (permanent, e.g. a dev VM that runs on demand)
   - \`maintenance\` (temporary, planned work)

   Either via UI or \`qm set <vmid> --tags <existing-tags>,no-alert\`.

2. The \`PveGuestDown\` rule now joins on \`pve_guest_info\` filtered with \`tags!~\".*(no-alert|maintenance).*\"\`, so tagged VMs no longer match the alert expression.

3. A second rule, \`PveGuestMaintenanceTagStale\`, fires at \`info\` severity if a \`maintenance\` tag has been on a VM for over 24 hours. This is the safety net so a forgotten tag is surfaced rather than silently masking a real outage.

## Test plan

After merge and ArgoCD sync:

- [ ] \`kubectl logs -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus | grep -i 'reload'\` shows a clean reload, no rule errors.
- [ ] In Prometheus UI / API, \`up{job=\"proxmox\"}\` is healthy and the new rules show under \`/rules\`.
- [ ] Pick a stopped non-critical VM (e.g. 114 autopilot-win11), set \`onboot=1\` temporarily, wait 5 min, confirm \`PveGuestDown\` fires.
- [ ] \`qm set 114 --tags autopilot,no-alert\`, wait one scrape interval, confirm the alert resolves.
- [ ] Remove the tag, confirm it fires again.
- [ ] Restore original onboot setting on 114.