### PR TITLE
chore(monitoring): discord-alert-proxy QoL (priority class, cleanup, docs)

### DIFF
--- a/infrastructure/monitoring/alertmanager-config.yaml
+++ b/infrastructure/monitoring/alertmanager-config.yaml
@@ -89,6 +89,11 @@ stringData:
             url: "http://discord-alert-proxy.monitoring.svc:9095/webhook"
       - name: healthchecks
         webhook_configs:
+          # HC.io expects ping requests (any GET/POST to the ping URL
+          # is a liveness signal). send_resolved: true would cause
+          # AlertManager to POST a resolved-alert JSON body that HC.io
+          # does not interpret, and can show as a failed ping in the
+          # event log. Keep this false.
           - send_resolved: false
             url_file: /etc/alertmanager/secrets/healthchecks-watchdog/url
             max_alerts: 0

--- a/infrastructure/monitoring/discord-alert-proxy/deployment.yaml
+++ b/infrastructure/monitoring/discord-alert-proxy/deployment.yaml
@@ -23,13 +23,17 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
     spec:
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app: discord-alert-proxy
+      # system-cluster-critical keeps the alerter from being evicted
+      # before the workloads it monitors under node memory pressure.
+      # A PDB (pdb.yaml) prevents voluntary eviction but does not protect
+      # against kubelet-level eviction, which is what this priority class
+      # addresses.
+      priorityClassName: system-cluster-critical
+      # Soft pod anti-affinity keeps the two replicas on different nodes
+      # when possible. Previously paired with a topologySpreadConstraint
+      # expressing the same intent; dropped that to avoid two overlapping
+      # declarations (both soft, so they did not conflict, but only one
+      # is needed).
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary

Three small improvements from the 2026-04-14 review pass on #115.

## Changes

### 1. Add \`priorityClassName: system-cluster-critical\`
The PDB from #115 covers voluntary eviction, but kubelet-level eviction under node memory pressure is governed by priority. Without this, the alerter can be evicted before the noisy workloads it is monitoring, putting us back in the 04-13 situation where nothing reached Discord. \`system-cluster-critical\` is the standard priority class for components whose failure degrades the cluster's ability to self-report.

### 2. Drop \`topologySpreadConstraints\`
It expressed the same "spread across hostnames" intent as the existing soft \`podAntiAffinity\`. Both being soft meant they never conflicted, but two overlapping declarations are confusing to read. Kept the \`podAntiAffinity\` and added a comment noting the decision.

### 3. Document \`send_resolved: false\` on the HC.io receiver
Added an inline comment in \`alertmanager-config.yaml\` explaining why it must stay \`false\`. HC.io interprets any HTTP request to the ping URL as a liveness signal; flipping this to \`true\` makes AlertManager POST a resolved-alert JSON body that HC.io does not understand and logs as a failed ping. Saves the next person ten minutes.

## Test plan
- [ ] After merge + ArgoCD sync, \`kubectl get pod -n monitoring -l app=discord-alert-proxy -o jsonpath='{.items[*].spec.priorityClassName}'\` returns \`system-cluster-critical system-cluster-critical\`.
- [ ] \`kubectl get pod -n monitoring -l app=discord-alert-proxy -o wide\` still shows the two replicas on different nodes (podAntiAffinity still honored).
- [ ] Discord alerts continue to deliver (smoke-test by firing a test alert or waiting for next Watchdog cycle).
- [ ] HC.io event log shows successful pings (comment only, no behavior change).