### PR TITLE
chore(ci): Dependabot + weekly rebuild + Trivy scan for discord-alert-proxy image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+updates:
+  # Pinned Python deps baked into the discord-alert-proxy image.
+  # A new fastapi/uvicorn/httpx CVE surfaces as an auto-PR here.
+  - package-ecosystem: pip
+    directory: /infrastructure/monitoring/discord-alert-proxy
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - monitoring
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  # Base image tag in the Dockerfile. When a new python:3.12-slim
+  # digest ships (Debian security update), Dependabot opens a PR.
+  - package-ecosystem: docker
+    directory: /infrastructure/monitoring/discord-alert-proxy
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - monitoring
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+
+  # GitHub Actions used by our workflows. Catches supply-chain
+  # pinning in docker/build-push-action, actions/checkout, etc.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope

--- a/.github/workflows/build-discord-alert-proxy.yml
+++ b/.github/workflows/build-discord-alert-proxy.yml
@@ -47,7 +47,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        # Authenticate for every event that pushes (push to main,
+        # workflow_dispatch, AND schedule). The build step's push
+        # condition is `github.event_name != 'pull_request'`, so login
+        # must match the same condition; otherwise scheduled rebuilds
+        # try to push anonymously and fail with a 401.
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/build-discord-alert-proxy.yml
+++ b/.github/workflows/build-discord-alert-proxy.yml
@@ -16,6 +16,13 @@ on:
       - "infrastructure/monitoring/discord-alert-proxy/requirements.txt"
       - "infrastructure/monitoring/discord-alert-proxy/.dockerignore"
       - ".github/workflows/build-discord-alert-proxy.yml"
+  # Weekly rebuild even when nothing changed in git. Picks up new
+  # python:3.12-slim digests (Debian security updates) so the image
+  # does not drift stale. Also re-runs the Trivy scan on the stored
+  # bits so newly disclosed CVEs fail the build even before
+  # Dependabot opens a bump PR.
+  schedule:
+    - cron: "0 13 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -25,6 +32,9 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  # Required for the Trivy scan to upload SARIF results to the
+  # repo's Security tab (Code scanning alerts).
+  security-events: write
 
 jobs:
   build:
@@ -49,16 +59,52 @@ jobs:
         run: |
           SHORT_SHA=$(git rev-parse --short=12 HEAD)
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          # Stamp scheduled / manual rebuilds so the image record in
+          # GHCR is traceable (base image may differ even when git HEAD
+          # did not change).
+          STAMP="$(date -u +%Y%m%d)"
+          echo "stamp=${STAMP}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and (on main) push
+      - name: Build (always) and push (on main, dispatch, or schedule)
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: infrastructure/monitoring/discord-alert-proxy
           file: infrastructure/monitoring/discord-alert-proxy/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/discord-alert-proxy:${{ steps.tags.outputs.short_sha }}
             ghcr.io/${{ github.repository_owner }}/discord-alert-proxy:latest
+            ghcr.io/${{ github.repository_owner }}/discord-alert-proxy:${{ steps.tags.outputs.stamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy (fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/discord-alert-proxy:${{ steps.tags.outputs.short_sha }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+
+      - name: Run Trivy again to produce SARIF for Code Scanning
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/discord-alert-proxy:${{ steps.tags.outputs.short_sha }}
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-discord-alert-proxy


### PR DESCRIPTION
## Summary

Closes the image-patching gap flagged in the 2026-04-14 review after #121 baked \`discord-alert-proxy\` into a proper image. That PR eliminated the runtime \`pip install\` problem, but without a patching cadence the pinned versions and \`python:3.12-slim\` base would age into CVEs silently.

## Three mechanisms

### 1. Dependabot (\`.github/dependabot.yml\`)
Weekly on Monday 06:00 America/Los_Angeles, across three ecosystems:

| Ecosystem | Directory | Watches |
|---|---|---|
| \`pip\` | \`/infrastructure/monitoring/discord-alert-proxy\` | \`requirements.txt\` (fastapi, uvicorn, httpx) |
| \`docker\` | \`/infrastructure/monitoring/discord-alert-proxy\` | Dockerfile \`FROM python:3.12-slim\` (bumps when a new minor/patch ships) |
| \`github-actions\` | \`/\` | docker/build-push-action, actions/checkout, aquasecurity/trivy-action, etc. |

Labels (\`dependencies\`, \`monitoring\`, \`ci\`) and commit prefixes (\`chore(deps)\`, \`chore(ci)\`) are set so PRs slot into the existing review workflow.

### 2. Scheduled rebuild (\`build-discord-alert-proxy.yml\`)
New \`schedule: cron: "0 13 * * 1"\` (Mon 13:00 UTC, same wall-clock as Dependabot) rebuilds the image with the current \`HEAD\`'s source but a freshly-pulled \`python:3.12-slim\` base. Debian security updates land in the pushed image even when nothing in git changed.

Added a new dated tag \`:YYYYMMDD\` alongside \`:latest\` and \`:<short-sha>\` so the GHCR history of scheduled rebuilds is traceable.

### 3. Trivy scan (same workflow)
Two-pass:
- First pass uses \`format: table\` with \`exit-code: "1"\` and \`severity: HIGH,CRITICAL\`, \`ignore-unfixed: true\`. Fails the workflow if the just-built image has a fixable HIGH/CRITICAL.
- Second pass emits SARIF and uploads to the repo's Security tab via \`github/codeql-action/upload-sarif\`, so findings show up as Code Scanning alerts rather than just a workflow email.

PR builds remain side-effect free (\`load: true\`, \`push: false\`), but the Trivy scan still runs on the locally-built image. So a vulnerable PR fails before merge, not after.

## Test plan

- [ ] Merge, then visit the Actions tab and confirm the next \`build-discord-alert-proxy\` workflow (either triggered by this merge, or manually via \`workflow_dispatch\`) runs all steps green.
- [ ] Confirm Trivy produces a report in the workflow log.
- [ ] Visit Security > Code scanning and confirm the \`trivy-discord-alert-proxy\` category appears (empty is fine, means no HIGH/CRITICAL today).
- [ ] After Monday 06:00 PT, confirm Dependabot opens PRs for any pending updates (may be zero if everything is current).
- [ ] After Monday 13:00 UTC, confirm the scheduled workflow runs and pushes a new \`:YYYYMMDD\` tag to GHCR.