### PR TITLE
fix(science): stop DaskSchedulerDown/DaskNoWorkers false positives

### DIFF
--- a/apps/science/prometheus-rules.yaml
+++ b/apps/science/prometheus-rules.yaml
@@ -13,7 +13,12 @@ spec:
     - name: dask-availability
       rules:
         - alert: DaskSchedulerDown
-          expr: absent(up{job="dask-scheduler"} == 1)
+          # The scrape target in this cluster is named after the K8s
+          # service (lsdb-cluster-scheduler), not the generic
+          # dask-scheduler. The old rule matched zero series, so
+          # absent() returned 1 unconditionally and the alert fired
+          # permanently. Anchor on the real job label.
+          expr: absent(up{job="lsdb-cluster-scheduler"} == 1)
           for: 5m
           labels:
             severity: critical
@@ -21,13 +26,18 @@ spec:
             summary: "Dask scheduler is down"
             description: "The Dask scheduler (lsdb-cluster) has been unreachable for 5 minutes. No computations can be submitted."
         - alert: DaskNoWorkers
-          expr: dask_scheduler_workers == 0
+          # dask_scheduler_workers is dimensioned by state (idle,
+          # saturated, partially_saturated, paused, retiring). With one
+          # idle worker, idle=1 and the other four states=0, which made
+          # the old `== 0` rule fire four times permanently. Sum across
+          # states to get the actual worker count, per scheduler pod.
+          expr: sum by (namespace, pod) (dask_scheduler_workers) == 0
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Dask cluster has no workers"
-            description: "The Dask cluster (lsdb-cluster) has had 0 workers for 5 minutes. Submitted tasks cannot execute."
+            description: "The Dask cluster ({{ $labels.namespace }}/{{ $labels.pod }}) has had 0 workers for 5 minutes. Submitted tasks cannot execute."
     - name: dask-resources
       rules:
         - alert: DaskWorkerOOM


### PR DESCRIPTION
## Summary

Both Dask alerts have been firing permanently. Today's alert triage surfaced them as repeating noise.

## DaskSchedulerDown
Rule: \`absent(up{job=\"dask-scheduler\"} == 1)\`

But the actual Prometheus job label from the lsdb-cluster ServiceMonitor is \`lsdb-cluster-scheduler\` (the K8s service name). So the old rule matches zero series, \`absent()\` returns 1 unconditionally, alert fires forever.

**Fix**: \`absent(up{job=\"lsdb-cluster-scheduler\"} == 1)\`.

## DaskNoWorkers
Rule: \`dask_scheduler_workers == 0\`

\`dask_scheduler_workers\` is dimensioned by \`state\` label: \`idle\`, \`saturated\`, \`partially_saturated\`, \`paused\`, \`retiring\`. With one idle worker, \`state=idle\` is 1 and the other four are 0. The rule matches 4 series per scrape, permanently.

Verified live:
\`\`\`
dask_scheduler_workers{state="idle"}                = 1
dask_scheduler_workers{state="saturated"}           = 0
dask_scheduler_workers{state="partially_saturated"} = 0
dask_scheduler_workers{state="paused"}              = 0
dask_scheduler_workers{state="retiring"}            = 0
\`\`\`

**Fix**: \`sum by (namespace, pod) (dask_scheduler_workers) == 0\`. Aggregates across states, groups by the scheduler pod so multi-scheduler setups still get one alert per cluster.

## Test plan

- [ ] Merge, ArgoCD syncs, Prometheus reloads rules without errors.
- [ ] \`kubectl exec -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- wget -qO- 'http://localhost:9090/api/v1/query?query=sum+by(namespace,pod)(dask_scheduler_workers)'\` returns 1 (not 0).
- [ ] \`DaskSchedulerDown\` and \`DaskNoWorkers\` drop off the AlertManager firing list.
- [ ] Drain all Dask workers (\`kubectl scale deploy/dask-kubernetes-operator --replicas=0\`) and confirm \`DaskNoWorkers\` fires correctly after 5 minutes. Restore afterward.