### PR TITLE
fix(dashboard): fix NZBGet port and add Alertmanager external service

### DIFF
--- a/apps/dashboard/homepage/configmap.yaml
+++ b/apps/dashboard/homepage/configmap.yaml
@@ -144,9 +144,9 @@ data:
               key: "{{HOMEPAGE_VAR_JELLYSEERR_KEY}}"
         - NZBGet:
             icon: nzbget.png
-            href: http://192.168.1.226:10057
+            href: http://192.168.1.226:6789
             description: Usenet downloader
-            siteMonitor: http://192.168.1.226:10057
+            siteMonitor: http://192.168.1.226:6789
         - qBittorrent:
             icon: qbittorrent.png
             href: http://192.168.1.226:8080
@@ -177,7 +177,7 @@ data:
             siteMonitor: http://192.168.1.171:5601
         - Alertmanager:
             icon: alertmanager.png
-            href: http://192.168.1.230:9093
+            href: http://alertmanager-external.monitoring.svc:9093
             description: Alert routing to Discord
 
     - Temperatures:

--- a/infrastructure/monitoring/alertmanager-external-svc.yaml
+++ b/infrastructure/monitoring/alertmanager-external-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-external
+  namespace: monitoring
+  labels:
+    app: alertmanager-external
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9093
+      targetPort: 9093
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: alertmanager
+    alertmanager: kube-prometheus-stack-alertmanager

--- a/infrastructure/monitoring/kustomization.yaml
+++ b/infrastructure/monitoring/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   - namespace.yaml
   - application.yaml
   - prometheus-external-svc.yaml
+  - alertmanager-external-svc.yaml
   - alertmanager-config.yaml
   - loki-external-svc.yaml
   - vector-aggregator-svc.yaml


### PR DESCRIPTION
## Summary

Two Homepage widgets weren't showing up properly at http://192.168.1.228:3000/.

## NZBGet (wrong port)
Config had port 10057, actual K8s service \`release-name-nzbget\` listens on 6789. Fixed href and siteMonitor.

## Alertmanager (no external access)
Config pointed to \`http://192.168.1.230:9093\` which is the \`prometheus-external\` LoadBalancer, but that only exposes port 9090 (Prometheus). Alertmanager was ClusterIP-only.

- Created \`alertmanager-external-svc.yaml\` (LoadBalancer, mirrors the existing prometheus-external pattern). MetalLB will auto-assign an IP from the 192.168.1.225-240 pool.
- Updated Homepage configmap to use cluster-internal DNS (\`alertmanager-external.monitoring.svc:9093\`) since Homepage runs inside K8s and gets faster, more reliable access that way.

## Authentik (not in this PR)
Widget returns 403. The API token in the \`homepage-api-keys\` secret is populated (64 chars) but appears revoked or expired in Authentik. Needs manual regeneration in Authentik admin UI + 1Password item update. ESO will re-sync after that.

## Test plan
- [ ] After merge + ArgoCD sync, NZBGet tile on Homepage shows status dot (green if running).
- [ ] Alertmanager tile shows status dot. Click through opens AlertManager UI on the MetalLB-assigned IP.
- [ ] \`kubectl get svc alertmanager-external -n monitoring\` shows an EXTERNAL-IP in the MetalLB range.
- [ ] Authentik: regenerate token in admin UI, update 1P item, wait for ESO refresh, confirm widget populates.