### PR TITLE
chore(eso): bump ExternalSecret refresh from 1h to 24h

### DIFF
--- a/apps/dashboard/homepage/externalsecret.yaml
+++ b/apps/dashboard/homepage/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: onepassword-infrastructure
     kind: ClusterSecretStore

--- a/infrastructure/monitoring/discord-alert-proxy/externalsecret.yaml
+++ b/infrastructure/monitoring/discord-alert-proxy/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: onepassword-infrastructure
     kind: ClusterSecretStore

--- a/infrastructure/monitoring/grafana-externalsecret.yaml
+++ b/infrastructure/monitoring/grafana-externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: onepassword-infrastructure
     kind: ClusterSecretStore

--- a/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
+++ b/infrastructure/monitoring/healthchecks-watchdog-externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  refreshInterval: 1h
+  refreshInterval: 24h
   secretStoreRef:
     name: onepassword-infrastructure
     kind: ClusterSecretStore


### PR DESCRIPTION
Reduces ESO's 1P API load from ~20 reads/hr to ~20 reads/day. See commit message for rationale. Manual sync after password changes via `kubectl annotate externalsecret <name> -n <ns> force-sync=$(date +%s) --overwrite`.