### PR TITLE
fix(nzbget): pin image to v25.3-ls212

### DIFF
--- a/apps/media/nzbget/common.yaml
+++ b/apps/media/nzbget/common.yaml
@@ -84,7 +84,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: release-name-nzbget
-          image: "lscr.io/linuxserver/nzbget:latest"
+          image: "lscr.io/linuxserver/nzbget:v25.3-ls212"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true

--- a/apps/media/nzbget/values.yaml
+++ b/apps/media/nzbget/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: lscr.io/linuxserver/nzbget
-  tag: "latest"
+  tag: "v25.3-ls212"
   pullPolicy: IfNotPresent
 
 imagePullSecrets:


### PR DESCRIPTION
## Summary
- Pins NZBGet image from `latest` to `v25.3-ls212` to prevent v26.0 config breakage
- NZBGet v26.0 requires `ControlUsername` (previously optional) and fails to create the default `ScriptDir` at `/app/nzbget/scripts`, which pauses all download activity
- Using `latest` with `imagePullPolicy: IfNotPresent` caused different nodes to run different versions (k8cluster1 had v26.0, k8cluster2 had v25.3)

## Also fixed (runtime, not in this PR)
- Patched NZBGet config: `ScriptDir=/config/scripts` (writable PVC path)
- Applied missing Jellyfin Endpoints object (ArgoCD excludes `Endpoints` resources globally via `argocd-cm`)
- Triggered Sonarr searches for For All Mankind and The 4400 (all monitored episodes now complete)

## Test plan
- [x] Verified NZBGet starts cleanly with no config errors after restart
- [x] Verified Sonarr can reach NZBGet and grab releases
- [x] Verified rendered manifest has correct pinned tag