### PR TITLE
chore(media): pin all container images to specific versions

### DIFF
--- a/apps/media/bazarr/common.yaml
+++ b/apps/media/bazarr/common.yaml
@@ -94,8 +94,8 @@ spec:
             value: America/Los_Angeles
           - name: UMASK
             value: "002"
-          image: lscr.io/linuxserver/bazarr:latest
-          imagePullPolicy: Always
+          image: lscr.io/linuxserver/bazarr:v1.5.6-ls344
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /

--- a/apps/media/bazarr/values.yaml
+++ b/apps/media/bazarr/values.yaml
@@ -12,8 +12,8 @@ controllers:
       main:
         image:
           repository: lscr.io/linuxserver/bazarr
-          tag: latest
-          pullPolicy: Always
+          tag: "v1.5.6-ls344"
+          pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/apps/media/jellyseer/common.yaml
+++ b/apps/media/jellyseer/common.yaml
@@ -94,7 +94,7 @@ spec:
             value: America/Los_Angeles
           - name: UMASK
             value: "002"
-          image: fallenbagel/jellyseerr:latest
+          image: fallenbagel/jellyseerr:2.7.3
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/apps/media/jellyseer/values.yaml
+++ b/apps/media/jellyseer/values.yaml
@@ -10,7 +10,7 @@ controllers:
       main:
         image:
           repository: fallenbagel/jellyseerr
-          tag: latest
+          tag: "2.7.3"
           pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/apps/media/prowlarr/common.yaml
+++ b/apps/media/prowlarr/common.yaml
@@ -94,8 +94,8 @@ spec:
             value: America/Los_Angeles
           - name: UMASK
             value: "002"
-          image: lscr.io/linuxserver/prowlarr:latest
-          imagePullPolicy: Always
+          image: lscr.io/linuxserver/prowlarr:2.3.5.5327-ls142
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /

--- a/apps/media/prowlarr/values.yaml
+++ b/apps/media/prowlarr/values.yaml
@@ -12,8 +12,8 @@ controllers:
       main:
         image:
           repository: lscr.io/linuxserver/prowlarr
-          tag: latest
-          pullPolicy: Always
+          tag: "2.3.5.5327-ls142"
+          pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/apps/media/qbittorrent/common.yaml
+++ b/apps/media/qbittorrent/common.yaml
@@ -91,7 +91,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: main
-          image: lscr.io/linuxserver/qbittorrent:latest
+          image: lscr.io/linuxserver/qbittorrent:5.1.4-r3-ls450
           imagePullPolicy: IfNotPresent
           env:
             - name: PGID

--- a/apps/media/qbittorrent/values.yaml
+++ b/apps/media/qbittorrent/values.yaml
@@ -10,7 +10,7 @@ controllers:
       main:
         image:
           repository: lscr.io/linuxserver/qbittorrent
-          tag: latest
+          tag: "5.1.4-r3-ls450"
           pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/apps/media/radarr/common.yaml
+++ b/apps/media/radarr/common.yaml
@@ -94,8 +94,8 @@ spec:
             value: America/Los_Angeles
           - name: UMASK
             value: "002"
-          image: lscr.io/linuxserver/radarr:latest
-          imagePullPolicy: Always
+          image: lscr.io/linuxserver/radarr:6.1.1.10360-ls299
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /

--- a/apps/media/radarr/values.yaml
+++ b/apps/media/radarr/values.yaml
@@ -12,8 +12,8 @@ controllers:
       main:
         image:
           repository: lscr.io/linuxserver/radarr
-          tag: latest
-          pullPolicy: Always
+          tag: "6.1.1.10360-ls299"
+          pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/apps/media/sonarr/common.yaml
+++ b/apps/media/sonarr/common.yaml
@@ -94,8 +94,8 @@ spec:
             value: America/Los_Angeles
           - name: UMASK
             value: "002"
-          image: lscr.io/linuxserver/sonarr:latest
-          imagePullPolicy: Always
+          image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls308
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /

--- a/apps/media/sonarr/values.yaml
+++ b/apps/media/sonarr/values.yaml
@@ -12,8 +12,8 @@ controllers:
       main:
         image:
           repository: lscr.io/linuxserver/sonarr
-          tag: latest
-          pullPolicy: Always
+          tag: "4.0.17.2952-ls308"
+          pullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
           runAsGroup: 0


### PR DESCRIPTION
## Summary
- Pins 6 remaining media apps from `latest` to their currently running versions
- Changes `pullPolicy: Always` to `IfNotPresent` for pinned tags
- Prevents silent breaking changes from upstream image updates (like the NZBGet v26 outage)

| App | Pinned Tag | Previous |
|-----|-----------|----------|
| sonarr | `4.0.17.2952-ls308` | `latest` |
| radarr | `6.1.1.10360-ls299` | `latest` |
| prowlarr | `2.3.5.5327-ls142` | `latest` |
| bazarr | `v1.5.6-ls344` | `latest` |
| jellyseerr | `2.7.3` | `latest` |
| qbittorrent | `5.1.4-r3-ls450` | `latest` |

Closes #136

## Test plan
- [x] Tags cross-referenced against Docker Hub
- [x] Versions obtained from live cluster pod logs
- [x] Rendered manifests verified with `make all`
- [ ] ArgoCD sync after merge