### PR TITLE
fix(media): ArgoCD PostSync hook for Jellyfin Endpoints

### DIFF
--- a/apps/media/jellyfin-endpoints-hook.yaml
+++ b/apps/media/jellyfin-endpoints-hook.yaml
@@ -1,0 +1,112 @@
+---
+# RBAC resources for the PostSync hook that creates Endpoints for the
+# external Jellyfin VM.  These are regular ArgoCD-managed resources
+# (no hook annotation) so they persist between syncs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jellyfin-endpoints-sync
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin-endpoints-sync
+    app.kubernetes.io/component: external-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jellyfin-endpoints-writer
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin-endpoints-sync
+    app.kubernetes.io/component: external-service
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jellyfin-endpoints-sync
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin-endpoints-sync
+    app.kubernetes.io/component: external-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jellyfin-endpoints-writer
+subjects:
+  - kind: ServiceAccount
+    name: jellyfin-endpoints-sync
+    namespace: media
+---
+# PostSync hook: applies the Endpoints object that ArgoCD's global
+# resource.exclusions prevents from being synced normally.
+# See: https://github.com/mithr4ndir/k8s-argocd/issues/134
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jellyfin-endpoints-sync
+  namespace: media
+  labels:
+    app.kubernetes.io/name: jellyfin-endpoints-sync
+    app.kubernetes.io/component: external-service
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jellyfin-endpoints-sync
+        app.kubernetes.io/component: external-service
+    spec:
+      serviceAccountName: jellyfin-endpoints-sync
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:1.31
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cat <<'MANIFEST' | kubectl apply -f -
+              apiVersion: v1
+              kind: Endpoints
+              metadata:
+                name: jellyfin
+                namespace: media
+                labels:
+                  app.kubernetes.io/name: jellyfin
+                  app.kubernetes.io/component: external-service
+                  app.kubernetes.io/managed-by: argocd-postsync-hook
+              subsets:
+                - addresses:
+                    - ip: 192.168.1.170
+                  ports:
+                    - port: 8096
+                      protocol: TCP
+              MANIFEST
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/apps/media/jellyfin-endpoints-hook.yaml
+++ b/apps/media/jellyfin-endpoints-hook.yaml
@@ -74,9 +74,15 @@ spec:
         fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: kubectl
           image: bitnami/kubectl:1.31
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           command:
             - /bin/sh
             - -c

--- a/apps/media/kustomization.yaml
+++ b/apps/media/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - media-pv-nfs.yaml
   - media-pvc.yaml
   - jellyfin-external-svc.yaml
-  - jellyfin-external-ep.yaml
+  - jellyfin-endpoints-hook.yaml
   - nzbget/
   - qbittorrent/
   - radarr/


### PR DESCRIPTION
## Summary
- Adds an ArgoCD PostSync hook Job that applies the Jellyfin Endpoints object after every sync
- Works around ArgoCD's global `resource.exclusions` for Endpoints/EndpointSlice
- Includes dedicated ServiceAccount, Role (least-privilege), and RoleBinding
- Job is hardened: non-root, read-only rootfs, all capabilities dropped, seccomp RuntimeDefault

## Why a PostSync hook?
- Jellyseerr stores the Jellyfin URL in `settings.json` on its PVC, not via env vars (can't change at deploy time)
- ExternalName services only work with DNS names, not bare IPs
- Removing the global Endpoints exclusion would degrade ArgoCD performance across all namespaces
- This is fully declarative, in git, survives namespace recreation and cluster rebuilds

Closes #134

## Test plan
- [x] `kubectl kustomize apps/media/` builds cleanly
- [x] `kubectl kustomize environments/dev/` builds cleanly
- [x] All hook resources receive correct namespace from Kustomize
- [ ] Verify PostSync Job runs after ArgoCD sync
- [ ] Verify Jellyseerr can resolve `jellyfin.media.svc.cluster.local`