### PR TITLE
feat(monitoring): add media service health alerts

### DIFF
--- a/infrastructure/monitoring/alertmanager-config.yaml
+++ b/infrastructure/monitoring/alertmanager-config.yaml
@@ -78,6 +78,12 @@ stringData:
           group_wait: 1m
           repeat_interval: 2h
         - matchers:
+            - namespace = "media"
+          receiver: discord
+          group_by: [alertname]
+          group_wait: 1m
+          repeat_interval: 1h
+        - matchers:
             - severity = critical
           receiver: discord
           repeat_interval: 1h

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -572,7 +572,10 @@ kube-prometheus-stack:
                 summary: "{{ $labels.deployment }} has been down for 5 minutes"
                 description: "Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} has 0 available replicas. The service is completely offline."
             - alert: MediaPodCrashLooping
-              expr: increase(kube_pod_container_status_restarts_total{namespace="media"}[1h]) > 5
+              expr: |
+                increase(kube_pod_container_status_restarts_total{namespace="media"}[1h]) > 5
+                and on (namespace, pod)
+                kube_pod_status_phase{namespace="media", phase="Running"} == 1
               for: 10m
               labels:
                 severity: warning

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -556,6 +556,43 @@ kube-prometheus-stack:
                 summary: "Security enforcement hasn't run in over 1 hour on {{ $labels.instance }}"
                 description: "Last security timer run was {{ $value | humanizeDuration }} ago on {{ $labels.instance }}. Wazuh/CrowdSec config enforcement is not converging."
 
+    media-service-health:
+      groups:
+        - name: media-services
+          rules:
+            - alert: MediaDeploymentUnavailable
+              expr: |
+                kube_deployment_status_replicas_available{namespace="media"} == 0
+                and
+                kube_deployment_spec_replicas{namespace="media"} > 0
+              for: 5m
+              labels:
+                severity: critical
+              annotations:
+                summary: "{{ $labels.deployment }} has been down for 5 minutes"
+                description: "Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} has 0 available replicas. The service is completely offline."
+            - alert: MediaPodCrashLooping
+              expr: increase(kube_pod_container_status_restarts_total{namespace="media"}[1h]) > 5
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "{{ $labels.pod }} is crash-looping ({{ $value | printf \"%.0f\" }} restarts/hr)"
+                description: "Container {{ $labels.container }} in pod {{ $labels.pod }} has restarted more than 5 times in the last hour. Check logs with: kubectl logs -n media {{ $labels.pod }} -c {{ $labels.container }} --previous"
+            - alert: MediaPodNotReady
+              expr: |
+                min by (namespace, pod) (
+                  kube_pod_status_ready{namespace="media", condition="true"}
+                ) == 0
+                and on (namespace, pod)
+                kube_pod_status_phase{namespace="media", phase="Running"} == 1
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "{{ $labels.pod }} not ready for 10+ minutes"
+                description: "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} has been running but not ready for over 10 minutes. Readiness probes may be failing."
+
   # Prometheus Operator
   prometheusOperator:
     enabled: true


### PR DESCRIPTION
## Summary
- Adds baseline health monitoring for all 7 media deployments using existing kube-state-metrics
- No new exporters needed, uses metrics already being collected
- Alerts route to Discord via the existing discord-alert-proxy (LOTR/Star Wars themed)

### PrometheusRules added
| Alert | Severity | Trigger |
|-------|----------|---------|
| MediaDeploymentUnavailable | critical | 0 available replicas for 5+ minutes |
| MediaPodCrashLooping | warning | >5 restarts in rolling 1-hour window, sustained 10m |
| MediaPodNotReady | warning | Pod running but not ready for 10+ minutes |

### Alertmanager routing
- Dedicated route for `namespace="media"` alerts, grouped by `alertname`
- 1-minute group wait, 1-hour repeat interval

Closes #135

## Test plan
- [x] PromQL validated against live Prometheus (all 7 media deployments produce expected metrics)
- [x] Rules follow existing `additionalPrometheusRulesMap` pattern
- [x] Alertmanager route placed before catch-all severity route
- [ ] Verify rules appear in Prometheus after ArgoCD sync
- [ ] Test by scaling a media deployment to 0 and checking Discord