### PR TITLE
feat(monitoring): 1Password quota alerts, runbook, Grafana dashboard

### DIFF
--- a/.spec-workflow/specs/1password-quota-monitoring/design.md
+++ b/.spec-workflow/specs/1password-quota-monitoring/design.md
@@ -1,0 +1,204 @@
+# Design Document
+
+## Overview
+
+Three pieces wired through existing infrastructure, no new components:
+
+1. **Collector script + systemd timer** (ansible-managed): calls `op service-account ratelimit`, parses the table output, writes Prometheus textfile metrics every 15 min on command-center1.
+2. **Prometheus alert rules** (k8s-argocd): four graduated alerts on the `account read_write` daily metric, plus a staleness alert on the collector itself.
+3. **Grafana panel**: added to an existing Infrastructure or Monitoring dashboard.
+
+The collector sits in ansible-quasarlab because the `op` CLI and token live on command-center1, not in the K8s cluster. The metric text file is read by the node_exporter textfile collector that already runs there. The alert rules and Grafana panel live in k8s-argocd because that's where all monitoring config already lives.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+- Uses existing systemd timer + textfile collector pattern that ansible-quasarlab already uses for `ansible_run.prom`, `ansible_security.prom`, `unattended_upgrades.prom`, `etcd_maintenance.prom`. Zero new infrastructure.
+- Uses existing kill-switch library (`scripts/lib/op-killswitch.sh`) so the collector respects the same rate-limit protections as every other op caller.
+- Uses PromQL alert style already established (PveGuestDown, EtcdDbSizeLarge) with `for:` thresholds, severity labels, and runbook_url annotations.
+
+### Project Structure (structure.md)
+- Ansible role: `ansible-quasarlab/roles/op_quota_collector/` (parallel to `unattended_upgrades/` and `k8s_maintenance/`).
+- Alert rules: `k8s-argocd/infrastructure/monitoring/kube-prometheus-stack/values.yaml` under `additionalPrometheusRulesMap` (where all custom rules already live).
+- Grafana panel: inline JSON added to an existing dashboard ConfigMap under `k8s-argocd/infrastructure/monitoring/grafana-dashboards/`.
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`scripts/lib/op-killswitch.sh`** (ansible-quasarlab): The collector sources this and calls `op_killswitch_check_or_exit` at the top, `op_killswitch_scan_file` after `op` fails. Same pattern as `run-proxmox.sh` and `vault-pass.sh`.
+- **`OP_SERVICE_ACCOUNT_TOKEN` from `~/.config/op/service-account-token`**: The collector reads this the same way the existing wrappers do. Read-only token is sufficient; `op service-account ratelimit` is a read.
+- **Node exporter textfile directory `/var/lib/node_exporter/textfiles/`**: Already scraped, already has file ownership and dir sticky-bit set. Reuse without changes.
+- **`additionalPrometheusRulesMap` in kube-prometheus-stack values.yaml**: Add a new group alongside `vm-node-alerts`, `proxmox-alerts`, `etcd-health`, etc.
+
+### Integration Points
+
+- **node_exporter on command-center1**: Scrapes `/var/lib/node_exporter/textfiles/*.prom` every 15s, emits metrics into Prometheus via the existing scrape config. No change needed.
+- **Prometheus in K8s**: Scrapes node_exporter. Alerts fire through the existing AlertManager to Discord via discord-alert-proxy. No change needed.
+- **Grafana**: Provisioned via the existing sidecar, reads dashboards from ConfigMaps with label `grafana_dashboard=1`. No change needed.
+
+## Architecture
+
+```mermaid
+graph LR
+  Timer[systemd timer<br/>every 15m] --> Script[op-quota-collector.sh]
+  Script --> KS{kill switch<br/>tripped?}
+  KS -- yes --> Skip[write success=0<br/>preserve old metrics]
+  KS -- no --> OP[op service-account ratelimit]
+  OP --> Parser[python table parser]
+  Parser --> Prom[/var/lib/node_exporter/<br/>textfiles/<br/>op_quota.prom/]
+  Prom --> NE[node_exporter]
+  NE --> P[Prometheus]
+  P --> A[AlertManager]
+  P --> G[Grafana panel]
+  A --> D[Discord]
+```
+
+### Modular Design Principles
+
+- **op-quota-collector.sh**: one responsibility, wrap `op` call and persist to textfile. Script is short enough (~80 lines) that no further decomposition is needed.
+- **op-quota-parse.py**: 30-line helper that takes the `op` table on stdin, emits Prometheus text format on stdout. Separated from the shell so it can be unit-tested with canned fixtures.
+- **Ansible role**: same shape as `unattended_upgrades` and `k8s_maintenance`. One tasks file, templates for the script/service/timer, defaults for the schedule.
+
+## Components and Interfaces
+
+### op-quota-collector.sh
+
+- **Purpose:** Orchestrate the full collect-parse-write cycle for one run.
+- **Inputs:** Environment via `/home/ladino/.config/op/service-account-token`. No CLI arguments.
+- **Output:** Atomic write of `/var/lib/node_exporter/textfiles/op_quota.prom`. Zero stdout on success, syslog line via `logger -t op-quota-collector` on any failure.
+- **Exit code:** Always 0. A failure must not prevent the next firing. Success/failure is surfaced through the `onepassword_ratelimit_collector_success` metric.
+- **Dependencies:** `op` CLI, `scripts/lib/op-killswitch.sh`, `op-quota-parse.py`.
+- **Reuses:** `op_killswitch_check_or_exit`, `op_killswitch_scan_file` from the kill-switch lib.
+
+### op-quota-parse.py
+
+- **Purpose:** Turn the `op service-account ratelimit` table into Prometheus textfile format.
+- **Inputs:** Table text on stdin, e.g.:
+  ```
+  TYPE       ACTION        LIMIT    USED    REMAINING    RESET
+  token      write         100      0       100          N/A
+  token      read          1000     0       1000         N/A
+  account    read_write    1000     1000    0            5 hours from now
+  ```
+- **Output:** Prometheus text format on stdout, e.g.:
+  ```
+  # HELP onepassword_ratelimit_used Requests used in the current window.
+  # TYPE onepassword_ratelimit_used gauge
+  onepassword_ratelimit_used{type="token",action="read"} 0
+  onepassword_ratelimit_used{type="token",action="write"} 0
+  onepassword_ratelimit_used{type="account",action="read_write"} 1000
+  onepassword_ratelimit_limit{type="account",action="read_write"} 1000
+  onepassword_ratelimit_remaining{type="account",action="read_write"} 0
+  onepassword_ratelimit_reset_seconds{type="account",action="read_write"} 18000
+  onepassword_ratelimit_collector_success 1
+  onepassword_ratelimit_collector_timestamp_seconds 1776500000
+  ```
+- **Reset parsing:** "N/A" becomes absent (no metric line). "5 hours from now" becomes 18000. "23 hours and 59 minutes from now" becomes 86340. Never negative.
+- **Reuses:** Python stdlib only (`re`, `sys`, `time`).
+
+### systemd timer + service
+
+- `op-quota-collector.timer`: `OnCalendar=*:0/15` (every 15 min), `Persistent=true`.
+- `op-quota-collector.service`: `Type=oneshot`, `User=ladino`, `ExecStart=/usr/local/bin/op-quota-collector.sh`.
+- Both deployed by `roles/op_quota_collector`.
+
+### Alert rule group
+
+Appended to `additionalPrometheusRulesMap` in `kube-prometheus-stack/values.yaml`:
+
+```yaml
+onepassword-quota:
+  groups:
+    - name: onepassword-quota-daily
+      rules:
+        - alert: OnePasswordQuotaHalfConsumed
+          expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 500
+          for: 15m
+          labels: { severity: info }
+        - alert: OnePasswordQuotaLow
+          expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 200
+          for: 10m
+          labels: { severity: warning }
+        - alert: OnePasswordQuotaCritical
+          expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 50
+          for: 5m
+          labels: { severity: critical }
+        - alert: OnePasswordQuotaExhausted
+          expr: onepassword_ratelimit_remaining{type="account",action="read_write"} == 0
+          for: 0m
+          labels: { severity: critical }
+        - alert: OnePasswordQuotaCollectorStale
+          expr: onepassword_ratelimit_collector_success == 0
+          for: 30m
+          labels: { severity: warning }
+```
+
+### Grafana panel
+
+Added to an existing dashboard ConfigMap in `k8s-argocd/infrastructure/monitoring/grafana-dashboards/`. Target dashboard: whichever Infrastructure/Monitoring dashboard currently shows homelab health (the one with the temperatures panel is a likely candidate).
+
+Panels:
+- Gauge: `onepassword_ratelimit_used{type="account"} / onepassword_ratelimit_limit{type="account"}` with thresholds at 0.5/0.8/0.95.
+- Time series: `onepassword_ratelimit_used{type="account"}` over 24h with annotation lines at 500, 800, 950.
+- Stat: `onepassword_ratelimit_reset_seconds{type="account"}` formatted as duration ("4h 32m").
+
+## Data Models
+
+### Prometheus textfile schema
+
+```
+onepassword_ratelimit_used{type,action}           gauge
+onepassword_ratelimit_limit{type,action}          gauge
+onepassword_ratelimit_remaining{type,action}      gauge
+onepassword_ratelimit_reset_seconds{type,action}  gauge  (absent when reset=N/A)
+onepassword_ratelimit_collector_success           gauge  (0 or 1)
+onepassword_ratelimit_collector_timestamp_seconds gauge
+```
+
+Labels:
+- `type`: one of `token`, `account`
+- `action`: one of `read`, `write`, `read_write`
+
+## Error Handling
+
+### Error Scenarios
+
+1. **`op` CLI not installed or not in PATH:**
+   - **Handling:** Collector logs to syslog, writes `onepassword_ratelimit_collector_success 0`, preserves any existing metric file, exits 0.
+   - **User Impact:** `OnePasswordQuotaCollectorStale` fires after 30m. Operator investigates the collector host.
+
+2. **Kill switch tripped at collector start:**
+   - **Handling:** `op_killswitch_check_or_exit` exits the script before calling `op`. Collector logs a distinct reason (`killswitch=active`), writes `success=0` to the metric file (preserving old data on the other metric lines), exits 0.
+   - **User Impact:** Same alert (`CollectorStale`), operator correlates with kill-switch status.
+
+3. **`op` returns a rate-limit error (429) on the ratelimit call itself:**
+   - **Handling:** `op_killswitch_scan_file` trips the kill switch, collector logs, writes `success=0`, preserves old metrics, exits 0.
+   - **User Impact:** Ironic but handled. The kill switch suppresses all op callers until the limit clears. Metrics go stale; `CollectorStale` fires. This confirms we hit the cap even without live metrics.
+
+4. **Table parse fails (e.g. 1Password changes the output format):**
+   - **Handling:** Python helper exits non-zero with a parse error on stderr. Shell captures stderr to syslog, writes `success=0`, preserves old metrics.
+   - **User Impact:** `CollectorStale` fires. Operator inspects the `logger -t op-quota-collector` journal entries and updates the parser.
+
+5. **Textfile directory not writable:**
+   - **Handling:** Shell check at collector start. Logs a clear error, exits 0.
+   - **User Impact:** `CollectorStale`. Operator fixes perms via the existing textfile dir ownership.
+
+## Testing Strategy
+
+### Unit Testing
+
+- **op-quota-parse.py:** Table fixtures captured from real `op` output plus synthetic edge cases (all `N/A` resets, all-exhausted, mixed). Assert exact Prometheus text output byte-for-byte. Run via `python3 -m pytest` in the role's `tests/` directory.
+- **op-quota-collector.sh:** `bash -n` syntax check. Integration rather than unit tested because shell logic is mostly wiring.
+
+### Integration Testing
+
+- **Manual run on command-center1** after deploy: `sudo -u ladino /usr/local/bin/op-quota-collector.sh`, then `cat /var/lib/node_exporter/textfiles/op_quota.prom`. Expect valid Prometheus text.
+- **Kill switch simulation:** `./scripts/op-killswitch-status.sh trip`, run collector, confirm `success=0` metric and no new `op` call in the journal. Then `clear` and confirm next run populates metrics.
+- **Parser regression:** Feed each fixture through the live collector path via a test harness in the role.
+
+### End-to-End Testing
+
+- **Prometheus scrape:** After deploy, `kubectl exec -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- wget -qO- 'http://localhost:9090/api/v1/query?query=onepassword_ratelimit_used'` should return non-empty results within 30 seconds.
+- **Alert fire drill:** Manually set a low threshold variant (e.g. `< 999`) temporarily, confirm Discord receives the alert, then revert. Validates the full chain end-to-end.
+- **Grafana panel:** Open dashboard, confirm gauge/time-series/stat all render with live data.

--- a/.spec-workflow/specs/1password-quota-monitoring/requirements.md
+++ b/.spec-workflow/specs/1password-quota-monitoring/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+Add observability for the 1Password service account daily rate limit so we get a loud, actionable signal before we exhaust the quota instead of discovering it via an outage. The 2026-04-18 incident pinned the quasarlab 1Password account's 1000-request daily cap for ~24 hours, silently breaking every ExternalSecret sync and ansible playbook run that needs secrets. The rate limit was invisible until we found the undocumented `op service-account ratelimit` command.
+
+The feature is a Prometheus-scrapable metric source, a set of alert rules, and a Grafana panel covering hourly-per-token and daily-per-account usage. It uses the existing node_exporter textfile collector pattern already in use for ansible metrics, so no new scrape target is required.
+
+## Alignment with Product Vision
+
+The homelab's prime directive is "everything must be managed in code (IaC), no manual configuration." That extends to operational visibility: if a service limit can silently fail the cluster, we must know about it before it does. This spec closes the last visibility gap in the 1Password defense-in-depth series that already includes the kill switch (PR #104), secret caching (PR #105-#106), and 24h ESO refresh (PR #131).
+
+## Requirements
+
+### Requirement 1: Collect 1Password quota usage on a schedule
+
+**User Story:** As an operator, I want the current 1Password daily and hourly rate-limit usage exposed as Prometheus metrics, so that I can see real-time utilization on Grafana and set alert thresholds on it.
+
+#### Acceptance Criteria
+
+1. WHEN the quota collector runs THEN it SHALL call `op service-account ratelimit` once and parse its tabular output into labeled metrics.
+2. WHEN the collector runs THEN it SHALL write the metrics as a Prometheus textfile in the existing `/var/lib/node_exporter/textfiles/` directory so the existing node_exporter on command-center1 scrapes them.
+3. WHEN `op` is unavailable, the token is unset, or the rate limit is already exhausted (the ratelimit command itself can be blocked) THEN the collector SHALL preserve the last successful metric values, write an `onepassword_ratelimit_collector_success` gauge of `0`, and exit cleanly with a syslog line but not an error code.
+4. WHEN the kill switch (`/var/lib/ansible-quasarlab/1p-killswitch`) is active THEN the collector SHALL skip calling `op` to avoid extending the rate-limit window, but still refresh the `onepassword_ratelimit_collector_success` metric to `0` with a distinct syslog reason.
+5. WHEN the collector runs successfully THEN it SHALL emit at minimum: `onepassword_ratelimit_used`, `onepassword_ratelimit_limit`, `onepassword_ratelimit_remaining`, `onepassword_ratelimit_reset_seconds`, all labeled by `type` (`token|account`) and `action` (`read|write|read_write`).
+
+### Requirement 2: Schedule the collector
+
+**User Story:** As an operator, I want the quota collector to run often enough that alerts fire within minutes of hitting a threshold but not so often that it adds measurable load to the daily cap itself.
+
+#### Acceptance Criteria
+
+1. WHEN the schedule is configured THEN it SHALL be a systemd timer on command-center1 firing every 15 minutes.
+2. WHEN the collector runs THEN it SHALL consume exactly 1 request against the daily cap per firing (4/hour, 96/day = 9.6% of the 1000-daily cap).
+3. WHEN the timer is deployed THEN it SHALL be idempotent via Ansible and survive host reboots.
+
+### Requirement 3: Alert on quota exhaustion risk
+
+**User Story:** As an operator, I want graduated alerts on approaching the 1Password daily cap so I can intervene (pause automation, upgrade plan) before secrets stop syncing.
+
+#### Acceptance Criteria
+
+1. WHEN the account daily `remaining` drops below 500 (50%) for 15 minutes THEN the system SHALL fire `OnePasswordQuotaHalfConsumed` at `info` severity.
+2. WHEN the account daily `remaining` drops below 200 (20%) for 10 minutes THEN the system SHALL fire `OnePasswordQuotaLow` at `warning` severity with a runbook link.
+3. WHEN the account daily `remaining` drops below 50 (5%) for 5 minutes THEN the system SHALL fire `OnePasswordQuotaCritical` at `critical` severity.
+4. WHEN the account daily `remaining` equals 0 THEN the system SHALL fire `OnePasswordQuotaExhausted` at `critical` severity immediately.
+5. WHEN `onepassword_ratelimit_collector_success == 0` for 30 minutes THEN the system SHALL fire `OnePasswordQuotaCollectorStale` at `warning` severity so we notice the collector itself has failed (distinct from "quota is fine, just not being measured").
+
+### Requirement 4: Visualization
+
+**User Story:** As an operator, I want a Grafana panel that shows current quota usage and recent trend so I can correlate consumption spikes with scheduled jobs.
+
+#### Acceptance Criteria
+
+1. WHEN the panel loads THEN it SHALL display the current `used / limit` ratio as a gauge for the account daily limit, the token hourly read limit, and the token hourly write limit.
+2. WHEN the panel loads THEN it SHALL include a time-series showing `onepassword_ratelimit_used{type="account"}` over the last 24 hours with horizontal threshold lines at 50%, 80%, 95%.
+3. WHEN the panel loads THEN it SHALL include a single-value indicator for `onepassword_ratelimit_reset_seconds` (time until reset).
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- The collector is a single shell script plus a small Python helper for the awk-of-the-table parse. It lives under `ansible-quasarlab/roles/op_quota_collector/` (role), not k8s. Ansible manages the systemd unit and timer. The alert rules and Grafana panel live in k8s-argocd (this repo).
+- The script parses the CLI table output, not a JSON API, because `op service-account ratelimit` does not currently support `--format=json`. If 1Password adds JSON output in a future release, swap the parser with no downstream changes.
+- No new runtime dependencies. `op` is already present on command-center1 (used by ansible wrappers). Python 3 stdlib only, no `pip` packages.
+
+### Performance
+
+- Collector total runtime target: under 5 seconds per firing, including the `op` HTTP roundtrip and textfile atomic rename.
+- Each firing consumes exactly 1 request. No retries. If the call fails, the existing cached metric file is preserved and the next firing tries again.
+
+### Reliability
+
+- Textfile writes are atomic (write to `.tmp`, rename) so Prometheus never sees a partial file.
+- The collector reuses the kill-switch library from `ansible-quasarlab/scripts/lib/op-killswitch.sh` so a rate-limit event during its own `op` call does not re-extend the window.
+- On first deploy, the metric file does not exist; Prometheus scrape returns empty metrics and the alert rules correctly no-op until data arrives.
+
+### Usability
+
+- Operator runbook link on the warning/critical alerts points to `docs/runbooks/onepassword-quota.md` (to be created in k8s-argocd) with three actions: check usage, identify top consumers, pause offenders.
+- Grafana panel is added to an existing dashboard (Infrastructure or Monitoring), not a new one, so it is discovered alongside related metrics.

--- a/.spec-workflow/specs/1password-quota-monitoring/tasks.md
+++ b/.spec-workflow/specs/1password-quota-monitoring/tasks.md
@@ -1,0 +1,87 @@
+# Tasks Document
+
+Status update 2026-04-18: tasks 1-4 (ansible-quasarlab collector) shipped as PR #109 (merged `8637a3a`). Tasks 5-8 (this repo) previously had stale `[x]` marks without any artifacts on disk. Now actually delivered on branch `feat/1password-quota-monitoring`: alert rules + runbook + standalone Grafana dashboard + wiring. Task 9 (end-to-end smoke) remains pending until both PRs are deployed.
+
+- [ ] 1. Create op-quota-parse.py in ansible-quasarlab/roles/op_quota_collector/files/
+  - File: ansible-quasarlab/roles/op_quota_collector/files/op-quota-parse.py
+  - Parse `op service-account ratelimit` stdin, emit Prometheus text on stdout
+  - Handle "N/A" reset (omit line), "5 hours from now" style, "23 hours and 59 minutes" style
+  - Python 3 stdlib only (re, sys, time)
+  - Purpose: Convert CLI table output into metric format
+  - _Leverage: None (new helper, no existing parsers)_
+  - _Requirements: 1.5_
+
+- [ ] 2. Create op-quota-collector.sh template
+  - File: ansible-quasarlab/roles/op_quota_collector/templates/op-quota-collector.sh.j2
+  - Source scripts/lib/op-killswitch.sh, call op_killswitch_check_or_exit
+  - Load OP_SERVICE_ACCOUNT_TOKEN from ~/.config/op/service-account-token
+  - Capture op stderr, scan via op_killswitch_scan_file on failure
+  - Always exit 0, emit onepassword_ratelimit_collector_success on every path
+  - Atomic textfile rename
+  - Purpose: Orchestrate collection lifecycle
+  - _Leverage: ansible-quasarlab/scripts/lib/op-killswitch.sh_
+  - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+- [ ] 3. Create systemd service + timer templates
+  - Files:
+    - ansible-quasarlab/roles/op_quota_collector/templates/op-quota-collector.service.j2
+    - ansible-quasarlab/roles/op_quota_collector/templates/op-quota-collector.timer.j2
+  - Service: Type=oneshot, User=ladino, runs /usr/local/bin/op-quota-collector.sh
+  - Timer: OnCalendar=*:0/15 (every 15m), Persistent=true
+  - Purpose: Scheduled execution surviving reboots
+  - _Leverage: existing etcd-defrag.service/timer shape in roles/k8s_maintenance/templates/_
+  - _Requirements: 2.1, 2.3_
+
+- [ ] 4. Wire role into cmd_center.yml playbook + add parser tests
+  - Files:
+    - ansible-quasarlab/roles/op_quota_collector/tasks/main.yml (deploy script + parser + units, daemon-reload, enable timer)
+    - ansible-quasarlab/roles/op_quota_collector/defaults/main.yml (interval, paths)
+    - ansible-quasarlab/roles/op_quota_collector/tests/fixtures/*.txt (sample op outputs)
+    - ansible-quasarlab/roles/op_quota_collector/tests/test_parse.py (pytest assertions)
+    - ansible-quasarlab/playbooks/cmd_center.yml (add role)
+  - Purpose: Complete the ansible-side deployment + parser regression coverage
+  - _Leverage: roles/k8s_maintenance/tasks/main.yml as the shape reference_
+  - _Requirements: 1.1-1.5, 2.1-2.3_
+
+- [x] 5. Add PrometheusRule group in kube-prometheus-stack values.yaml
+  - File: k8s-argocd/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+  - New `onepassword-quota` group under `additionalPrometheusRulesMap`
+  - 5 alerts: OnePasswordQuotaHalfConsumed (info/50%/15m), Low (warning/20%/10m), Critical (critical/5%/5m), Exhausted (critical/0%/0m), CollectorStale (warning/30m)
+  - Each alert has runbook_url annotation pointing to docs/runbooks/onepassword-quota.md
+  - Purpose: Graduated severity matching urgency
+  - _Leverage: existing etcd-health group in the same file_
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [x] 6. Create runbook at docs/runbooks/onepassword-quota.md
+  - File: k8s-argocd/docs/runbooks/onepassword-quota.md
+  - Sections: what triggered the alert, `op service-account ratelimit` command to confirm, top 3 actions (trip kill switch, scale ESO to 0, identify biggest consumer via op-collector metrics)
+  - Include wait-time guidance for hourly vs daily limits
+  - Purpose: On-call has immediate next steps
+  - _Leverage: existing runbook pattern (if any) in the repo_
+  - _Requirements: 3.2 (linked runbook), NFR usability_
+
+- [x] 7. Add Grafana dashboard for 1Password quota (standalone, uid `onepassword-quota`)
+  - File: k8s-argocd/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-1password-quota.yaml
+  - 7 panels: 3 gauges (account daily, token hourly read, token hourly write), 3 stat (time-to-reset, collector health, collector age), 1 24h time-series with threshold lines at 500/800/950
+  - Wired via kustomization.yaml entry for infrastructure/monitoring/grafana-dashboards/
+  - Decision: standalone dashboard instead of panels grafted onto an existing overview, because the 1P cap is a distinct subsystem with its own on-call flow (runbook linked from alerts); mixing into quasarlab-overview dilutes the signal
+  - Purpose: At-a-glance quota visibility
+  - _Leverage: grafana-dashboard-ansible-ansible-runs.yaml as the ConfigMap shape reference_
+  - _Requirements: 4.1, 4.2, 4.3_
+
+- [x] 8. PR in k8s-argocd with rules + runbook + Grafana panel
+  - Open PR referencing this spec
+  - Title: "feat(monitoring): 1Password quota alerts, runbook, Grafana panel"
+  - Note in PR body that the collector (tasks 1-4) lives in ansible-quasarlab and is tracked in that repo's spec workflow
+  - Purpose: Ship the monitoring side independently of the collector deployment
+  - _Leverage: recent monitoring PRs (#132 etcd alerts) as the PR shape_
+  - _Requirements: all (this is the delivery vehicle)_
+
+- [ ] 9. End-to-end smoke test after both repos' PRs merge
+  - Verify: `kubectl exec prom -- wget ... query=onepassword_ratelimit_used` returns live data
+  - Verify: Grafana panel renders
+  - Verify: temporarily raise a threshold, confirm Discord receives themed alert, revert
+  - Verify: trip the kill switch, confirm `CollectorStale` fires after 30 min
+  - Purpose: Prove the full pipeline works end-to-end
+  - _Leverage: kubectl exec pattern already used for other monitoring validation_
+  - _Requirements: all acceptance criteria, integration testing per design doc_

--- a/docs/runbooks/onepassword-quota.md
+++ b/docs/runbooks/onepassword-quota.md
@@ -15,7 +15,7 @@ The alerts in this group watch the **daily account cap** because that is the one
 
 ## Confirm current state
 
-Run from a host with the `op` CLI and token (command-center1 is canonical). **This burns one request against the very quota you are investigating, so do it once, not in a loop.**
+Run from a host with the `op` CLI and token (command-center1 is canonical). `op service-account ratelimit` is a control-plane call that does NOT count against any of the three rate-limit tiers, so probe as often as you need during an incident (verified 2026-04-19 against a draining cap).
 
 ```bash
 ssh command-center1

--- a/docs/runbooks/onepassword-quota.md
+++ b/docs/runbooks/onepassword-quota.md
@@ -1,0 +1,100 @@
+# Runbook: 1Password Quota Alerts
+
+Applies to: `OnePasswordQuotaHalfConsumed`, `OnePasswordQuotaLow`, `OnePasswordQuotaCritical`, `OnePasswordQuotaExhausted`, `OnePasswordQuotaCollectorStale`.
+
+## Why you were paged
+
+1Password Families plan enforces **two** rate limits. Our cluster hits the second one far more often than the first:
+
+| Tier | Scope | Limit | Typical culprit |
+|---|---|---|---|
+| Per service account, hourly | Each SA token | 1000 reads/hr, 100 writes/hr | Runaway loop or cache miss storm |
+| **Per account, daily** | **Across all SAs in the 1P account** | **1000 read_write/24h** | **Normal operation over weeks accumulates, ESO retry loop, interactive `op` testing** |
+
+The alerts in this group watch the **daily account cap** because that is the one that causes cluster-wide outages. The 2026-04-18 incident pinned it for 24h and silently broke every `ExternalSecret` sync plus every ansible play that needed a secret.
+
+## Confirm current state
+
+Run from a host with the `op` CLI and token (command-center1 is canonical). **This burns one request against the very quota you are investigating, so do it once, not in a loop.**
+
+```bash
+ssh command-center1
+OP_SERVICE_ACCOUNT_TOKEN="$(cat ~/.config/op/service-account-token)" \
+  timeout 30 op service-account ratelimit
+```
+
+Example exhausted output:
+
+```
+TYPE       ACTION        LIMIT    USED    REMAINING    RESET
+token      write         100      0       100          N/A
+token      read          1000     0       1000         N/A
+account    read_write    1000     1000    0            2 hours from now
+```
+
+The `account read_write` row is what the alerts watch. `RESET` tells you when the window rolls over.
+
+## Immediate actions (in order)
+
+### 1. Trip the kill switch to stop bleeding
+
+The kill switch pauses every `op` caller in our fleet (ansible wrappers, ESO via the token, the quota collector itself). This prevents further consumption while you investigate.
+
+```bash
+ssh command-center1 'sudo touch /var/lib/ansible-quasarlab/1p-killswitch'
+```
+
+Verify:
+
+```bash
+ssh command-center1 'ls -la /var/lib/ansible-quasarlab/1p-killswitch'
+```
+
+The next op-quota-collector firing will see `success=0` with reason `killswitch` and stop calling `op` until the file is removed.
+
+### 2. Scale ESO to zero if the cap is exhausted or critical
+
+ESO retries silently on 429 with a ~6-minute backoff, which burns 10 requests/hour per ExternalSecret. With ~10 ExternalSecrets, that is ~100 reqs/hr of pure retry churn that prevents the window from draining cleanly. Stop it entirely:
+
+```bash
+kubectl scale deploy external-secrets -n external-secrets --replicas=0
+kubectl scale deploy external-secrets-webhook -n external-secrets --replicas=0
+kubectl scale deploy external-secrets-cert-controller -n external-secrets --replicas=0
+```
+
+Leave ESO down until the `RESET` window in step 1 passes AND `remaining` climbs back to 1000. Then scale back to 1 replica each.
+
+### 3. Identify the top consumer
+
+The collector alone uses 96 requests/day (every 15 min). ESO contributes the largest variable share. Interactive `op` testing during an outage adds a spike. If this fires outside of a post-incident period, something changed.
+
+Look at Grafana **1Password Quota** dashboard, "24h account usage" panel for the rate-of-change slope. Correlate spikes against:
+
+- **ESO refresh interval**: should be `24h` on all 4 ExternalSecrets. Check [infrastructure/external-secrets/](/home/ladino/code/k8s-argocd/infrastructure/external-secrets/); see the refreshInterval history in PR #131.
+- **Ansible playbook runs**: each one pulls 1-4 secrets via `op` wrappers. Frequent reruns during a debugging session are the #1 non-automation cause.
+- **New service accounts**: when you add a new SA, ESO may kick off full sync of all referenced items, consuming N requests immediately.
+
+### 4. After reset: reintroduce load gradually
+
+1. Wait for `RESET` window to elapse. Re-probe with the single `op` call above.
+2. Confirm `remaining` is back at 1000.
+3. Remove kill switch: `ssh command-center1 'sudo rm /var/lib/ansible-quasarlab/1p-killswitch'`.
+4. Scale ESO back up: `kubectl scale deploy external-secrets -n external-secrets --replicas=1` (and the two other deployments).
+5. Watch the 1Password Quota dashboard for the first hour. Usage should rise slowly, not in a vertical spike.
+
+## Root-cause patterns
+
+| Symptom | Likely cause | Prevention |
+|---|---|---|
+| `Exhausted` fires once a day, same hour | ESO retry loop on a bad ExternalSecret reference | Fix the broken reference, don't blame the cap |
+| `Exhausted` fires out of the blue | Interactive `op` testing without caching | Use the wrappers in [scripts/lib/op-secret-cache.sh](https://github.com/mithr4ndir/ansible-quasarlab/blob/main/scripts/lib/op-secret-cache.sh), not raw `op` loops |
+| `CollectorStale` alone (no quota alert) | Collector script itself failed. Token unreadable, `op` missing, kill switch tripped but not cleared | `journalctl -t op-quota-collector -n 50` |
+| `QuotaLow` but `reset` says 23 hours | Someone just started the window with a burst. Will resolve as the window slides or when they stop | Watch for 1 hour. If slope stays flat/decreasing, ignore |
+
+## Related
+
+- RCA: `k8s-argocd/2026-04-18_etcd_instability_rca.md` (memory bank) includes the parallel 1P incident.
+- Daily cap finding: `k8s-argocd/1password-daily-rate-limit.md` (memory bank).
+- Collector role: [ansible-quasarlab/roles/op_quota_collector](https://github.com/mithr4ndir/ansible-quasarlab/tree/main/roles/op_quota_collector).
+- Kill-switch library: [scripts/lib/op-killswitch.sh](https://github.com/mithr4ndir/ansible-quasarlab/blob/main/scripts/lib/op-killswitch.sh).
+- Defense-in-depth PRs: #104 (kill switch), #105/#106 (secret caching), #131 (ESO 24h refresh).

--- a/docs/runbooks/onepassword-quota.md
+++ b/docs/runbooks/onepassword-quota.md
@@ -91,6 +91,50 @@ Look at Grafana **1Password Quota** dashboard, "24h account usage" panel for the
 | `CollectorStale` alone (no quota alert) | Collector script itself failed. Token unreadable, `op` missing, kill switch tripped but not cleared | `journalctl -t op-quota-collector -n 50` |
 | `QuotaLow` but `reset` says 23 hours | Someone just started the window with a burst. Will resolve as the window slides or when they stop | Watch for 1 hour. If slope stays flat/decreasing, ignore |
 
+## ExternalSecret Retry Alerts
+
+Applies to: `ExternalSecretNotReady`, `ExternalSecretSyncErrorBurst`.
+
+These fire **upstream** of the quota alerts above. They catch the retry loop at its source (a broken ExternalSecret reference) before it drains enough quota to trip `OnePasswordQuotaLow`. If one of these fires, the account cap is probably still healthy but an ES is actively consuming it.
+
+### Triage
+
+```bash
+# See which ES is failing and the upstream error message
+kubectl describe externalsecret -n "$NS" "$NAME"
+
+# Check the ESO controller logs for the specific reconcile error
+kubectl logs -n external-secrets deploy/external-secrets --tail=100 | grep -i "$NAME"
+
+# Confirm the referenced 1Password item / field still exists
+OP_SERVICE_ACCOUNT_TOKEN="$(cat ~/.config/op/service-account-token)" \
+  op item get "<item-id>" --vault "<vault>" 2>&1 | head
+```
+
+### Common root causes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `item not found` in ESO logs | Referenced 1P item was deleted or moved vaults | Update the `remoteRef.key` in the ES spec, or recreate the item |
+| `field not found` | Field renamed in the 1P item | Update `remoteRef.property` to match the current field name |
+| `unauthorized` / `401` | Service account lost access to the vault | Re-grant vault access to the SA in 1P admin, or rotate the token |
+| `429 Too Many Requests` in logs, condition flaps | 1P cap is already exhausted AND ESO is looping | Trip the kill switch (above), scale ESO to 0, wait for reset |
+
+### Immediate containment if you can't fix the reference right now
+
+Stop the retry loop by disabling the failing ES until you can fix it:
+
+```bash
+# Annotate to prevent reconcile (ESO respects this)
+kubectl annotate externalsecret -n "$NS" "$NAME" \
+  external-secrets.io/reconcile-paused="true" --overwrite
+
+# Or delete the target Secret so at least the downstream workload fails loudly
+kubectl delete secret -n "$NS" "$TARGET_SECRET_NAME"
+```
+
+Un-pause with `kubectl annotate ... external-secrets.io/reconcile-paused-` once fixed.
+
 ## Related
 
 - RCA: `k8s-argocd/2026-04-18_etcd_instability_rca.md` (memory bank) includes the parallel 1P incident.

--- a/infrastructure/external-secrets/external-secrets/values.yaml
+++ b/infrastructure/external-secrets/external-secrets/values.yaml
@@ -18,3 +18,17 @@ external-secrets:
   # Limit concurrent reconciles to prevent retry storms from
   # overwhelming upstream secret providers (1Password, Vault, etc.)
   concurrent: 1
+
+  # ServiceMonitor so kube-prometheus-stack scrapes ESO metrics.
+  # Needed so ExternalSecretSyncError alerts fire on retry loops
+  # before they drain the 1Password daily cap (2026-04-18 incident).
+  # `release: kube-prometheus-stack` matches Prometheus operator's
+  # serviceMonitorSelector in the monitoring namespace.
+  serviceMonitor:
+    enabled: true
+    # alwaysRender: the ServiceMonitor CRD is present via kube-prometheus-stack,
+    # but `helm template` at ArgoCD render time can't detect it with the default
+    # `skipIfMissing` mode, so the SM would silently never deploy. Force render.
+    renderMode: alwaysRender
+    additionalLabels:
+      release: kube-prometheus-stack

--- a/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-1password-quota.yaml
+++ b/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-1password-quota.yaml
@@ -1,0 +1,362 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-1password-quota
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Infrastructure"
+data:
+  1password-quota.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "max": 1000,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "orange", "value": 50 },
+                  { "color": "yellow", "value": 200 },
+                  { "color": "green", "value": 500 }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+          "id": 1,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_remaining{type=\"account\",action=\"read_write\"}",
+              "legendFormat": "remaining",
+              "refId": "A"
+            }
+          ],
+          "title": "Account Daily Remaining (of 1000)",
+          "type": "gauge"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "max": 1000,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "orange", "value": 50 },
+                  { "color": "yellow", "value": 200 },
+                  { "color": "green", "value": 500 }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 },
+          "id": 2,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_remaining{type=\"token\",action=\"read\"}",
+              "legendFormat": "remaining",
+              "refId": "A"
+            }
+          ],
+          "title": "Token Hourly Read Remaining (of 1000)",
+          "type": "gauge"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "orange", "value": 5 },
+                  { "color": "yellow", "value": 20 },
+                  { "color": "green", "value": 50 }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 7, "w": 8, "x": 16, "y": 0 },
+          "id": 3,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_remaining{type=\"token\",action=\"write\"}",
+              "legendFormat": "remaining",
+              "refId": "A"
+            }
+          ],
+          "title": "Token Hourly Write Remaining (of 100)",
+          "type": "gauge"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 3600 },
+                  { "color": "red", "value": 7200 }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 5, "w": 8, "x": 0, "y": 7 },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_reset_seconds{type=\"account\",action=\"read_write\"}",
+              "legendFormat": "time to reset",
+              "refId": "A"
+            }
+          ],
+          "title": "Time Until Account Reset",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [
+                { "options": { "0": { "color": "red", "index": 0, "text": "FAILED" }, "1": { "color": "green", "index": 1, "text": "OK" } }, "type": "value" }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 5, "w": 8, "x": 8, "y": 7 },
+          "id": 5,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_collector_success",
+              "legendFormat": "collector",
+              "refId": "A"
+            }
+          ],
+          "title": "Collector Health",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 900 },
+                  { "color": "red", "value": 1800 }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 5, "w": 8, "x": 16, "y": 7 },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "time() - onepassword_ratelimit_collector_timestamp_seconds",
+              "legendFormat": "age",
+              "refId": "A"
+            }
+          ],
+          "title": "Time Since Last Collector Run",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "line" }
+              },
+              "mappings": [],
+              "max": 1000,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 500 },
+                  { "color": "orange", "value": 800 },
+                  { "color": "red", "value": 950 }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 9, "w": 24, "x": 0, "y": 12 },
+          "id": 7,
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_used{type=\"account\",action=\"read_write\"}",
+              "legendFormat": "account daily used",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "onepassword_ratelimit_used{type=\"token\",action=\"read\"}",
+              "legendFormat": "token hourly read used",
+              "refId": "B"
+            }
+          ],
+          "title": "Rate-Limit Consumption (24h)",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": ["infrastructure", "1password", "security"],
+      "templating": {
+        "list": [
+          {
+            "current": { "selected": false, "text": "Prometheus-K8s", "value": "Prometheus-K8s" },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": { "from": "now-24h", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "1Password Quota",
+      "uid": "onepassword-quota",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/infrastructure/monitoring/grafana-dashboards/kustomization.yaml
+++ b/infrastructure/monitoring/grafana-dashboards/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - grafana-dashboard-1password-quota.yaml
   - grafana-dashboard-ansible-ansible-runs.yaml
   - grafana-dashboard-kubernetes-cluster-overview.yaml
   - grafana-dashboard-kubernetes-k8s-logs.yaml

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -432,6 +432,61 @@ kube-prometheus-stack:
                 summary: "etcd db {{ $labels.pod }} is {{ $value | humanize1024 }} (critical)"
                 description: "etcd member {{ $labels.pod }} has a database larger than 200MB. This caused controller-manager crash-loops in the 2026-04-18 incident at 124MB. Immediate compaction + defrag required."
 
+    onepassword-quota:
+      groups:
+        - name: onepassword-quota
+          rules:
+            # Account-tier daily cap (Families plan: 1000 reads/day, shared across all service accounts).
+            # The 2026-04-18 incident pinned this for ~24h and silently broke every ExternalSecret sync.
+            # See ansible-quasarlab roles/op_quota_collector for the textfile source.
+            - alert: OnePasswordQuotaHalfConsumed
+              expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 500
+              for: 15m
+              labels:
+                severity: info
+              annotations:
+                summary: "1Password account quota at 50% ({{ $value }} remaining)"
+                description: "1Password daily account cap has dropped below 500/1000 remaining for 15m. Trend check: identify heaviest consumers before they push us toward critical."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            - alert: OnePasswordQuotaLow
+              expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 200
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "1Password account quota low ({{ $value }} remaining)"
+                description: "1Password daily account cap has dropped below 200/1000 remaining for 10m. Intervene now: pause non-critical automation or widen ESO refresh intervals. Reset in {{ with query \"onepassword_ratelimit_reset_seconds{type='account'}\" }}{{ . | first | value | humanizeDuration }}{{ end }}."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            - alert: OnePasswordQuotaCritical
+              expr: onepassword_ratelimit_remaining{type="account",action="read_write"} < 50
+              for: 5m
+              labels:
+                severity: critical
+              annotations:
+                summary: "1Password account quota CRITICAL ({{ $value }} remaining)"
+                description: "1Password daily account cap has dropped below 50/1000 remaining. Secrets are about to stop syncing. Trip the kill switch and scale ESO to 0 until reset."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            - alert: OnePasswordQuotaExhausted
+              expr: onepassword_ratelimit_remaining{type="account",action="read_write"} == 0
+              for: 0m
+              labels:
+                severity: critical
+              annotations:
+                summary: "1Password account quota EXHAUSTED"
+                description: "1Password daily account cap is fully consumed. Every `op` call will 429 until reset. ExternalSecret sync is broken. Trip kill switch, scale ESO to 0, wait for reset window."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            # Collector staleness: distinct from "quota is fine" so operator can tell measurement failure
+            # apart from a healthy cluster.
+            - alert: OnePasswordQuotaCollectorStale
+              expr: onepassword_ratelimit_collector_success == 0
+              for: 30m
+              labels:
+                severity: warning
+              annotations:
+                summary: "1Password quota collector failing on {{ $labels.instance }}"
+                description: "op-quota-collector has been reporting success=0 for 30m. Quota metrics are stale. Check `journalctl -t op-quota-collector -n 50` on the host. Common causes: kill switch tripped, token unreadable, `op` CLI missing."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+
     wazuh-health:
       groups:
         - name: wazuh-services

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -432,6 +432,36 @@ kube-prometheus-stack:
                 summary: "etcd db {{ $labels.pod }} is {{ $value | humanize1024 }} (critical)"
                 description: "etcd member {{ $labels.pod }} has a database larger than 200MB. This caused controller-manager crash-loops in the 2026-04-18 incident at 124MB. Immediate compaction + defrag required."
 
+    external-secrets-health:
+      groups:
+        - name: external-secrets-sync
+          rules:
+            # Catch ExternalSecret retry loops BEFORE they drain the 1Password
+            # daily cap. ESO retries on error with ~6min backoff regardless of
+            # refreshInterval, so a single bad reference can chew 200+/day.
+            # This alert fires within 10m of the first failed sync, vs
+            # OnePasswordQuotaLow which only fires after 800+ reads consumed.
+            - alert: ExternalSecretNotReady
+              expr: externalsecret_status_condition{condition="Ready",status="False"} == 1
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} not ready"
+                description: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} has been Ready=False for 10m. ESO is retrying on backoff and will burn 1Password quota until the reference is fixed or the ES is deleted. Check `kubectl describe externalsecret -n {{ $labels.namespace }} {{ $labels.name }}` for the upstream error."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md#externalsecret-retry-alerts"
+            # Active retry loop: >3 errors in 15min = ~12/hr = 288/day from one
+            # bad ES alone = 28% of the 1P daily cap per broken reference.
+            - alert: ExternalSecretSyncErrorBurst
+              expr: sum by (namespace, name) (increase(externalsecret_sync_calls_error[15m])) > 3
+              for: 5m
+              labels:
+                severity: warning
+              annotations:
+                summary: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} sync errors: {{ $value | printf \"%.0f\" }}/15m"
+                description: "ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} has produced more than 3 sync errors in the last 15 minutes. This is an active retry loop that will exhaust the 1Password daily cap if left for ~4 hours. Fix the upstream reference or delete the ES."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md#externalsecret-retry-alerts"
+
     onepassword-quota:
       groups:
         - name: onepassword-quota

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -505,6 +505,29 @@ kube-prometheus-stack:
                 summary: "1Password account quota EXHAUSTED"
                 description: "1Password daily account cap is fully consumed. Every `op` call will 429 until reset. ExternalSecret sync is broken. Trip kill switch, scale ESO to 0, wait for reset window."
                 runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            # Per-service-account hourly limits. Normally the account daily cap
+            # is the binding constraint, but a single SA looping on reads or a
+            # bulk-write script can trip the hourly tier first. Catches the
+            # runaway in ~10-15 min so we can fix the caller before the daily
+            # cap also drains.
+            - alert: OnePasswordTokenReadHourlyLow
+              expr: onepassword_ratelimit_remaining{type="token",action="read"} < 200
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "1Password SA hourly read quota low ({{ $value }} remaining of 1000)"
+                description: "A service account has burned more than 800/1000 hourly reads for 10m. Normal operation is well under 100/hr. Likely cause: runaway loop or cache miss storm on one caller. Identify via `journalctl -t op-wrapper` on command-center1."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
+            - alert: OnePasswordTokenWriteHourlyLow
+              expr: onepassword_ratelimit_remaining{type="token",action="write"} < 20
+              for: 5m
+              labels:
+                severity: warning
+              annotations:
+                summary: "1Password SA hourly write quota low ({{ $value }} remaining of 100)"
+                description: "A service account has burned more than 80/100 hourly writes for 5m. We almost never write from automation, so any burst is suspicious. Confirm it's not a rogue bulk-rotation script or misconfigured migration tool."
+                runbook_url: "https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/runbooks/onepassword-quota.md"
             # Collector staleness: distinct from "quota is fine" so operator can tell measurement failure
             # apart from a healthy cluster.
             - alert: OnePasswordQuotaCollectorStale


### PR DESCRIPTION
## Summary

Adds the k8s-side observability to match the collector shipped in ansible-quasarlab#109.

- New \`onepassword-quota\` PrometheusRule group with 5 graduated alerts (info/warning/critical) on the account-tier daily cap plus a collector-staleness alert
- New runbook at \`docs/runbooks/onepassword-quota.md\` covering the two-tier limit model, confirmation procedure, and remediation steps
- New standalone Grafana dashboard (uid \`onepassword-quota\`, folder Infrastructure): 3 gauges, 3 stats, 1 24h time-series with threshold lines

## Context

The 2026-04-18 incident pinned the 1P account's 1000-request daily cap for ~24h, silently breaking every ExternalSecret sync. The underlying mistake was that the per-service-account hourly limits were visible in our head but the per-account daily limit was not. This PR closes the last visibility gap in the 1P defense-in-depth series (kill switch #104, secret caching #105/#106, 24h ESO refresh #131).

## Related

- Collector (ansible-quasarlab): mithr4ndir/ansible-quasarlab#109 (merged \`8637a3a\`)
- Etcd RCA from same day: ansible-quasarlab#107 (merged)
- Spec: \`.spec-workflow/specs/1password-quota-monitoring/\` (requirements/design/tasks). Previously stale \`[x]\` marks corrected.

## Test plan

- [ ] ArgoCD syncs \`monitoring\` app without drift
- [ ] PrometheusRule \`kube-prometheus-stack-onepassword-quota\` appears in the \`monitoring\` namespace
- [ ] Grafana picks up the dashboard ConfigMap (\`grafana-dashboard-1password-quota\`) and it renders in the Infrastructure folder
- [ ] Metrics query \`onepassword_ratelimit_remaining{type="account"}\` returns values once the collector runs on command-center1 (requires ansible-quasarlab play to deploy the role)
- [ ] Temporarily raise a threshold, confirm Discord receives themed alert, revert
- [ ] Confirm \`CollectorStale\` fires when the kill switch is tripped for >30m