### PR TITLE
fix(media): replace broken bitnami/kubectl image in jellyfin endpoints hook

### DIFF
--- a/apps/media/jellyfin-endpoints-hook.yaml
+++ b/apps/media/jellyfin-endpoints-hook.yaml
@@ -79,7 +79,11 @@ spec:
           emptyDir: {}
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.31
+          # Bitnami removed public Docker Hub images in 2025; bitnami/kubectl:1.31
+          # now 404s. alpine/kubectl matches cluster minor (v1.33.11) and has the
+          # shell this Job's heredoc needs. Pin to patch version so supply-chain
+          # scans flag tag drift.
+          image: alpine/kubectl:1.33.4
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
## Summary

Replaces \`bitnami/kubectl:1.31\` with \`alpine/kubectl:1.33.4\` in the Jellyfin Endpoints PostSync hook (added in #138).

## Problem

Bitnami removed their public Docker Hub images earlier this year. \`bitnami/kubectl:1.31\` returns 404. The hook pod \`jellyfin-endpoints-sync-*\` has been in \`ImagePullBackOff\` with hundreds of retries.

Impact was soft: the Endpoints object this hook applies already exists from prior successful runs, so in-cluster workloads (Jellyseerr, etc.) resolving \`jellyfin.media.svc.cluster.local\` still routed correctly to the external VM at \`192.168.1.170:8096\`. But any manual delete or modification of that Endpoints object would no longer be self-healed by the hook.

## Solution

\`alpine/kubectl:1.33.4\`:
- Public Docker Hub, no auth
- Matches cluster minor version (v1.33.11) exactly
- Has \`/bin/sh\` (required by the Job's heredoc-driven \`kubectl apply\`)
- Pinned to patch version for supply-chain drift detection

Rejected: \`chainguard/kubectl\` (distroless, no shell), \`bitnamilegacy/kubectl\` (Bitnami has flagged this path for eventual retirement too).

Stuck Job + pod were cleaned up manually so the next sync creates a fresh one.

## Test plan

- [ ] On merge, ArgoCD PostSync hook Job \`jellyfin-endpoints-sync\` runs to Completion (not ImagePullBackOff)
- [ ] \`kubectl get endpoints -n media jellyfin\` still returns \`192.168.1.170:8096\`
- [ ] Delete the Endpoints object manually; trigger a sync; verify the hook recreates it
- [ ] Jellyseerr in-cluster access to Jellyfin via \`jellyfin.media.svc.cluster.local\` keeps working