### PR TITLE
docs(specs): record 2026-04-19 post-merge state

### DIFF
--- a/.spec-workflow/specs/1password-quota-monitoring/tasks.md
+++ b/.spec-workflow/specs/1password-quota-monitoring/tasks.md
@@ -77,11 +77,26 @@ Status update 2026-04-18: tasks 1-4 (ansible-quasarlab collector) shipped as PR 
   - _Leverage: recent monitoring PRs (#132 etcd alerts) as the PR shape_
   - _Requirements: all (this is the delivery vehicle)_
 
-- [ ] 9. End-to-end smoke test after both repos' PRs merge
-  - Verify: `kubectl exec prom -- wget ... query=onepassword_ratelimit_used` returns live data
-  - Verify: Grafana panel renders
-  - Verify: temporarily raise a threshold, confirm Discord receives themed alert, revert
-  - Verify: trip the kill switch, confirm `CollectorStale` fires after 30 min
-  - Purpose: Prove the full pipeline works end-to-end
+- [~] 9. End-to-end smoke test after both repos' PRs merge (partial, blocked on collector deployment)
+  - [x] ArgoCD dev app adopted the Grafana dashboard ConfigMap cleanly
+  - [x] PrometheusRule groups `onepassword-quota` (7 alerts) and `external-secrets-health` (2 alerts) deployed and visible in Prometheus UI
+  - [x] 3 ExternalSecrets ServiceMonitors deployed via chart `serviceMonitor.enabled=true, renderMode=alwaysRender`
+  - [ ] Live `onepassword_ratelimit_*` metrics in Prometheus. Blocked on ansible-quasarlab deploying the op-ratelimit-collector via `cmd_center.yml --tags op_ratelimit_collector`. Will not land until 1P cap recovers (stuck at ~100/1000 remaining on 2026-04-19 after an ansible retry storm).
+  - [ ] Threshold-flip Discord smoke test. Can run immediately (rule deploys independent of metric data) but deferred until real metric flow so the alert fires on authentic condition, not synthetic.
+  - [ ] `OnePasswordQuotaCollectorStale` for-30m test. Requires collector deployed + running briefly, then kill-switch tripped.
   - _Leverage: kubectl exec pattern already used for other monitoring validation_
   - _Requirements: all acceptance criteria, integration testing per design doc_
+
+- [ ] 10. 2026-04-19 follow-up: second round of alerts for ESO retry-loop detection (shipped in same PR #140)
+  - [x] ExternalSecretNotReady (warning, 10m on `externalsecret_status_condition{Ready,False}==1`)
+  - [x] ExternalSecretSyncErrorBurst (warning, 5m on `increase(externalsecret_sync_calls_error[15m]) > 3`)
+  - [x] Runbook extended with ExternalSecret Retry Alerts section (triage, root-cause table, reconcile-paused containment)
+  - [x] Per-SA hourly token tier alerts added: OnePasswordTokenReadHourlyLow (<200/1000) and OnePasswordTokenWriteHourlyLow (<20/100)
+  - _Leverage: ESO chart native ServiceMonitor, existing runbook_
+  - _Requirements: defense-in-depth on the incident class that bit us on 2026-04-18_
+
+- [x] 11. 2026-04-19 learning: confirm `op service-account ratelimit` is a free control-plane call
+  - Previous assumption: every ratelimit probe costs 1 read, hence collector 15m cadence (96/day = 9.6% of 1000 cap)
+  - Verified against a draining cap: USED counter stayed flat across back-to-back probes
+  - Implication: tighten collector cadence to 5m (PR #121 in ansible-quasarlab); remove "costs a read" warnings from runbook
+  - Auto-memory updated at `~/.claude/projects/-home-ladino/memory/feedback_op_rate_limit_care.md`

--- a/.spec-workflow/specs/jellyfin-endpoints-fix/tasks.md
+++ b/.spec-workflow/specs/jellyfin-endpoints-fix/tasks.md
@@ -29,8 +29,14 @@
   - All hook resources receive correct `media` namespace
   - _Requirements: 3_
 
-- [ ] 6. Merge PR #138 and verify PostSync hook fires
-  - Confirm Job runs after ArgoCD sync
-  - Verify Endpoints object exists: `kubectl get endpoints jellyfin -n media`
-  - Verify Jellyseerr sync: check logs for successful Jellyfin API calls
+- [x] 6. Merge PR #138 and verify PostSync hook fires
+  - PR #138 merged 2026-04-18. Endpoints object created at 192.168.1.170:8096.
+  - Jellyseerr sync verified working against the in-cluster Service DNS.
   - _Requirements: 1_
+
+- [x] 7. 2026-04-19 fix: replace broken bitnami/kubectl image (PR #143)
+  - Issue: `bitnami/kubectl:1.31` went 404 when Bitnami removed public Docker Hub images in 2025. PostSync hook pods stuck in ImagePullBackOff for ~67 min. Endpoints object survived from prior runs so downstream Jellyseerr kept working, but self-healing was broken.
+  - Fix: `alpine/kubectl:1.33.4` (matches cluster minor, has `/bin/sh` for heredoc, pinned to patch version).
+  - Verified: manual `kubectl apply -f apps/media/jellyfin-endpoints-hook.yaml` ran Job to completion in 7s, log shows `endpoints/jellyfin configured`. ArgoCD will now run it cleanly on next sync.
+  - Captured in memory bank (this repo) as supply-chain-drift learning: public base images can disappear, prefer pinned-patch + trivy scanning.
+  - _Requirements: 1, 3_


### PR DESCRIPTION
## Summary

Catches the spec-workflow tasks up to what actually shipped today.

**\`jellyfin-endpoints-fix\`**
- Task 6 complete (PR #138 merged, Endpoints healthy, Jellyseerr routing works)
- New task 7 captures the \`bitnami/kubectl:1.31\` image-removed-from-Docker-Hub incident and its PR #143 fix (swap to \`alpine/kubectl:1.33.4\`, pinned to patch)

**\`1password-quota-monitoring\`**
- Task 9 downgraded to partial. Rules, dashboard, ServiceMonitors all deployed via PR #140; live metric flow and Discord smoke test blocked on collector rollout in ansible-quasarlab (which is itself blocked on 1P cap recovery)
- New task 10 documents the ExternalSecret retry-loop alerts and per-SA hourly token tier alerts that shipped in the same PR #140 bundle
- New task 11 documents the 2026-04-19 finding that \`op service-account ratelimit\` is a free control-plane call, tightened collector cadence 15m → 5m, runbook updated, auto-memory updated

## Test plan

Docs-only, no code. Renders correctly on the spec-workflow dashboard.