### PR TITLE
docs(claude-bridge): clarify bridge gates Bash only, not all agent activity

### DIFF
--- a/docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md
+++ b/docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md
@@ -93,6 +93,7 @@ Out of scope:
 - Pre-approval policies (e.g., automatically approve known-safe `terraform apply` patterns). Future work, see Future Considerations.
 - HTTP Interactions endpoint mode. Gateway-only.
 - Hosting the bridge outside the cluster as a non-K8s fallback. See break-glass section for the Phase 0 emergency override; a true off-cluster fallback is deferred.
+- **Gating non-Bash agent activity.** The `PreToolUse` hook is registered with a `Bash` matcher only. Plan and brainstorm generation (e.g., `/ce:plan`, `/ce:brainstorm`, `/ce:work`), file edits via the `Edit` and `Write` tools, file reads, slash command invocations inside Claude Code, and any other tool that is not `Bash` flow without bridge involvement. The bridge is not a content gate or an audit log of "what the agent worked on"; it is a blast-radius gate on shell commands matching the Tier 3 deny list. (One narrow exception: a future `PostToolUse` hook captures pre-edit file content into `~/.claude/edit-snapshots/` for Tier 2 undo, see Unit 8. That hook records, it does not gate.)
 
 ### Deferred to Separate Tasks
 


### PR DESCRIPTION
## Summary

Adds one Out of Scope bullet to the master plan making explicit what was previously only implied at line 381 (the `PreToolUse` hook is registered with a `Bash` matcher).

The bridge gates Tier 3 Bash commands matching the deny list. It does NOT gate:
- Plan / brainstorm generation (`/ce:plan`, `/ce:brainstorm`, `/ce:work`).
- File edits via the `Edit` or `Write` tools.
- File reads.
- Slash command invocations inside Claude Code.
- Any other tool that is not `Bash`.

These flow without bridge involvement.

Narrow exception noted: a future `PostToolUse` hook (Unit 8) captures pre-edit file content into `~/.claude/edit-snapshots/` for Tier 2 undo. That hook RECORDS, it does not GATE.

## Why

A reviewer reasonably wondered whether the bridge would intercept agent planning artifacts. The plan's Scope Boundaries section did not say. This commit closes that gap so future reviewers (and future me) do not have to infer.

## Test plan

- [x] No em-dashes introduced
- [x] No structural change to the plan
- [x] Reads cleanly in Out of Scope context