### PR TITLE
feat(automation): claude-bridge K8s manifests (Unit 10)

### DIFF
--- a/apps/automation/automation-namespace.yaml
+++ b/apps/automation/automation-namespace.yaml
@@ -1,0 +1,14 @@
+---
+# Namespace for autonomous-agent control-plane workloads (claude-bridge,
+# future agent runners, etc.). Kept separate from `monitoring` and `media`
+# so NetworkPolicy and RBAC scope cleanly to "things that talk to LLMs or
+# Discord on behalf of operators".
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: automation
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/automation/claude-bridge/configmap.yaml
+++ b/apps/automation/claude-bridge/configmap.yaml
@@ -1,0 +1,34 @@
+---
+# Non-secret runtime config. Discord snowflakes (guild + channel IDs)
+# are not cryptographic secrets, but rotating them is rare and they fit
+# the ConfigMap shape better than ESO.
+#
+# IMPORTANT: replace the placeholder snowflakes below with the real
+# guild/channel IDs from the QuasarLab Discord server before the first
+# sync. Operator handoff:
+#   1. Discord Developer Portal -> bridge bot -> Bot tab -> copy guild ID
+#   2. Right-click each channel in Discord (with Developer Mode on) ->
+#      Copy ID
+# Channel layout per the master plan:
+#   - bot-activity      (Tier 1 read-only sweeps)
+#   - bot-proposals     (Tier 2 reversible, default-proceed)
+#   - bot-approvals     (Tier 3 hard-gated)
+#   - bot-digest        (06:00 daily digest of auto-proceeded Tier 2s)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: claude-bridge-config
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+data:
+  CLAUDE_BRIDGE_DISCORD_ENABLED: "true"
+  # QuasarLab Discord guild + the four bot-* channels.
+  CLAUDE_BRIDGE_DISCORD_GUILD_ID: "398359757800603650"
+  CLAUDE_BRIDGE_DISCORD_ACTIVITY_CHANNEL_ID: "1497986580256919756"
+  CLAUDE_BRIDGE_DISCORD_PROPOSALS_CHANNEL_ID: "1497989411986735277"
+  CLAUDE_BRIDGE_DISCORD_APPROVALS_CHANNEL_ID: "1497989457385619676"
+  CLAUDE_BRIDGE_DISCORD_DIGEST_CHANNEL_ID: "1498466462929518642"
+  # Default INFO; raise to DEBUG when triaging without a code change.
+  CLAUDE_BRIDGE_LOG_LEVEL: "INFO"

--- a/apps/automation/claude-bridge/deployment.yaml
+++ b/apps/automation/claude-bridge/deployment.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claude-bridge
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+    app.kubernetes.io/component: hitl-bridge
+    app.kubernetes.io/part-of: automation
+spec:
+  # Single replica is mandatory: the bridge holds a Discord Gateway
+  # WebSocket and registers slash commands. Two replicas double-fire
+  # interaction handlers (memory: feedback_single_replica_discord_gateway).
+  # Multi-replica with leader election is a deferred change.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: claude-bridge
+  # Recreate, not RollingUpdate. Single Gateway connection plus a single
+  # 8080 port mean two pods cannot coexist briefly without contention.
+  # Tradeoff: ~10s of unavailability per deploy, acceptable for an
+  # approval bridge whose tokens have a 15-minute TTL.
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: claude-bridge
+        app.kubernetes.io/name: claude-bridge
+        app.kubernetes.io/component: hitl-bridge
+      annotations:
+        # Reloader restarts the pod when the ConfigMap or referenced
+        # Secret changes. ESO refresh + 1P rotation flow goes:
+        # 1P -> ESO -> Secret update -> Reloader trigger -> pod restart
+        # -> bridge picks up new HMAC current secret on the next request.
+        reloader.stakater.com/auto: "true"
+    spec:
+      # system-cluster-critical: the bridge gates dangerous actions across
+      # the homelab; if it dies under memory pressure, autonomous agents
+      # lose their hard-block path. Same priority as discord-alert-proxy.
+      priorityClassName: system-cluster-critical
+      # 60s grace lets the bot send Discord disconnect frames cleanly and
+      # finish in-flight HTTP requests. Default 30s sometimes truncates
+      # the Gateway close handshake.
+      terminationGracePeriodSeconds: 60
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bridge
+          # 12-char short SHA matches the GHCR tag emitted by the
+          # claude-bridge CI on merges to main. Operator bumps this line
+          # via PR after a tested image is published. Same convention as
+          # discord-alert-proxy (image: ghcr.io/.../discord-alert-proxy:<sha>).
+          image: ghcr.io/mithr4ndir/claude-bridge:11c71d3f5437
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: claude-bridge-config
+            - secretRef:
+                name: claude-bridge-secrets
+          # Container is read-only-root (Dockerfile already supports it);
+          # /tmp is the only writable path the FastAPI stack needs (e.g.,
+          # for occasional uvicorn reload artefacts and Python tempfile).
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            # 6 * 10s = 60s of grace before pulling out of rotation. /readyz
+            # checks both Discord Gateway (connected) and Postgres (1s SELECT 1).
+            # A momentary DB hiccup or Gateway resume should not flap traffic.
+            failureThreshold: 6
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            # Cold start: alembic-style models import + asyncpg pool open +
+            # Discord Gateway login + slash command sync can take ~20-30s.
+            # 30 * 2s = 60s budget before liveness takes over.
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/apps/automation/claude-bridge/externalsecret.yaml
+++ b/apps/automation/claude-bridge/externalsecret.yaml
@@ -1,0 +1,97 @@
+---
+# Pulls every cryptographic secret the bridge needs from the
+# `Infrastructure` 1Password vault via the existing
+# onepassword-infrastructure ClusterSecretStore. Reloader watches this
+# Secret and restarts the deployment when any key changes (e.g., HMAC
+# rotation, key revocation).
+#
+# Item IDs (matching the discord-alert-proxy convention; ESO's
+# onepasswordSDK provider resolves by item ID, not title):
+#   rtdvrnr6emcan2tgqa4ctpr4qi  claude-bridge/discord-bot-token
+#   gwlimgxxn2uzul7pdfmkzairki  claude-bridge/server-hmac-secret
+#   67oqrbim2quqtx3jqz54h23wfi  claude-bridge/api-key-local-hook
+#   t4o74mhjfvhyhag354taybi23i  claude-bridge/api-key-remote-agent
+#   adt3c6cuittlebov2lod7pxilq  claude-bridge/allowlist
+#   wvdgy2x2r7wqgy2oot2wmuqdci  claude-bridge/postgres-dsn
+#
+# All secrets MUST be at least 32 chars where applicable. The bridge's
+# pydantic-settings layer validates shape at startup; a misconfigured
+# value crash-loops loudly rather than fails silently at first use.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-bridge-secrets
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  # 24h matches the existing infrastructure pattern. After rotating a
+  # 1P item, the operator kicks off a manual ESO sync (see memory:
+  # feedback_eso_sync_after_1p_change.md) instead of waiting.
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword-infrastructure
+    kind: ClusterSecretStore
+  target:
+    name: claude-bridge-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: CLAUDE_BRIDGE_DISCORD_BOT_TOKEN
+      remoteRef:
+        key: rtdvrnr6emcan2tgqa4ctpr4qi/token
+    - secretKey: CLAUDE_BRIDGE_DISCORD_ALLOWLIST_USER_IDS
+      remoteRef:
+        key: adt3c6cuittlebov2lod7pxilq/user_ids
+    - secretKey: CLAUDE_BRIDGE_HMAC_CURRENT
+      remoteRef:
+        key: gwlimgxxn2uzul7pdfmkzairki/current
+    # `previous` is populated only during the 15-minute rotation overlap;
+    # ESO syncs an empty value the rest of the time, which the bridge's
+    # HmacSettings.previous_bytes() handles as None (no token verification
+    # against the previous slot).
+    - secretKey: CLAUDE_BRIDGE_HMAC_PREVIOUS
+      remoteRef:
+        key: gwlimgxxn2uzul7pdfmkzairki/previous
+    - secretKey: CLAUDE_BRIDGE_API_KEYS_LOCAL_HOOK
+      remoteRef:
+        key: 67oqrbim2quqtx3jqz54h23wfi/keys
+    - secretKey: CLAUDE_BRIDGE_API_KEYS_REMOTE_AGENT
+      remoteRef:
+        key: t4o74mhjfvhyhag354taybi23i/keys
+    - secretKey: CLAUDE_BRIDGE_POSTGRES_DSN
+      remoteRef:
+        key: wvdgy2x2r7wqgy2oot2wmuqdci/dsn
+---
+# Migration credentials live in a separate Secret because the migrate
+# role has DDL permissions that the runtime pod must NEVER hold. Keeping
+# them in distinct K8s Secrets means a future pod-spec mistake (e.g.,
+# accidentally referencing the wrong secret) fails at envFrom resolution
+# rather than handing DDL to the request path.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: claude-bridge-migrate-secrets
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+    app.kubernetes.io/component: migrations
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword-infrastructure
+    kind: ClusterSecretStore
+  target:
+    name: claude-bridge-migrate-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: CLAUDE_BRIDGE_MIGRATE_DSN
+      remoteRef:
+        key: wvdgy2x2r7wqgy2oot2wmuqdci/migrate_dsn

--- a/apps/automation/claude-bridge/externalsecret.yaml
+++ b/apps/automation/claude-bridge/externalsecret.yaml
@@ -82,6 +82,13 @@ metadata:
     app.kubernetes.io/component: migrations
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    # sync-wave "-2" places this ExternalSecret BEFORE the migration
+    # Job (wave "-1") and the Deployment (default wave "0") within the
+    # Sync phase. ArgoCD waits for the ExternalSecret to be Healthy
+    # (Ready condition, which ESO sets only after the K8s Secret has
+    # been produced) before progressing, so the Job's envFrom resolves
+    # cleanly on first sync.
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   refreshInterval: 24h
   secretStoreRef:

--- a/apps/automation/claude-bridge/kustomization.yaml
+++ b/apps/automation/claude-bridge/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: automation
+resources:
+  - configmap.yaml
+  - externalsecret.yaml
+  - migration-job.yaml
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+  - networkpolicy.yaml
+  - prometheus-rules.yaml

--- a/apps/automation/claude-bridge/migration-job.yaml
+++ b/apps/automation/claude-bridge/migration-job.yaml
@@ -1,9 +1,18 @@
 ---
-# ArgoCD PreSync hook: runs `alembic upgrade head` before any
-# Deployment changes are applied. If the migration fails, the sync
-# fails, and the new bridge image is never rolled out: the running pod
-# continues serving the previous schema. This is the standard "DB
-# migrations gate the rollout" pattern.
+# ArgoCD Sync hook: runs `alembic upgrade head` during the Sync phase
+# at sync-wave "-1", which is AFTER the migrate ExternalSecret (wave
+# "-2") and BEFORE the Deployment (default wave 0). If the migration
+# fails, the sync fails and the new bridge image is never rolled out:
+# the running pod continues serving the previous schema. This is the
+# standard "DB migrations gate the rollout" pattern.
+#
+# Why Sync hook (not PreSync): the migrate-role Secret is produced by
+# ESO from a regular ExternalSecret resource that lives in the Sync
+# phase. PreSync hooks run BEFORE the Sync phase begins, so the
+# migrate Secret would not exist yet when this Job tried to mount it
+# via envFrom. Using a Sync hook with sync-wave ordering lets ArgoCD
+# wait for the ExternalSecret to be Healthy (which ESO marks only
+# after the K8s Secret has materialized) before this Job starts.
 #
 # The job runs the SAME image as the bridge (alembic.ini lives in the
 # repo and is baked into the image), but with a different DSN env var
@@ -25,7 +34,8 @@ metadata:
     app.kubernetes.io/name: claude-bridge
     app.kubernetes.io/component: migrations
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "-1"
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   # 2 retries before the sync is marked failed. Migrations are

--- a/apps/automation/claude-bridge/migration-job.yaml
+++ b/apps/automation/claude-bridge/migration-job.yaml
@@ -1,0 +1,94 @@
+---
+# ArgoCD PreSync hook: runs `alembic upgrade head` before any
+# Deployment changes are applied. If the migration fails, the sync
+# fails, and the new bridge image is never rolled out: the running pod
+# continues serving the previous schema. This is the standard "DB
+# migrations gate the rollout" pattern.
+#
+# The job runs the SAME image as the bridge (alembic.ini lives in the
+# repo and is baked into the image), but with a different DSN env var
+# (CLAUDE_BRIDGE_MIGRATE_DSN, claude_bridge_migrate role) and an
+# overridden command (alembic instead of uvicorn).
+#
+# hook-delete-policy: BeforeHookCreation,HookSucceeded
+#   - BeforeHookCreation: previous job artifacts are removed before a
+#     new run, so each sync gets a clean job (re-runnable).
+#   - HookSucceeded: artifacts are pruned on success (no clutter).
+#   - On failure, the job sticks around for `kubectl logs` triage.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: claude-bridge-migrate
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+    app.kubernetes.io/component: migrations
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  # 2 retries before the sync is marked failed. Migrations are
+  # idempotent (alembic checks current revision before applying), so a
+  # transient asyncpg connect error is the typical cause of retry.
+  backoffLimit: 2
+  # Job lingers for 5 minutes after success for log inspection, then
+  # the controller GCs it. On failure, the job is retained until the
+  # next successful sync (HookSucceeded only prunes on success).
+  ttlSecondsAfterFinished: 300
+  # 10-minute hard wall. Bridge migrations are tiny today (3 revisions
+  # totaling ~30 statements). Bumped above 5min default to absorb DDL
+  # locks under contention on the shared 192.168.1.123 cluster.
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        app: claude-bridge
+        app.kubernetes.io/name: claude-bridge
+        app.kubernetes.io/component: migrations
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: alembic
+          image: ghcr.io/mithr4ndir/claude-bridge:11c71d3f5437
+          imagePullPolicy: IfNotPresent
+          # alembic.ini reads sqlalchemy.url from CLAUDE_BRIDGE_MIGRATE_DSN
+          # via a ConfigParser interpolation override in env.py (Unit 3).
+          # `upgrade head` is idempotent: applies pending revisions, no-ops
+          # when the DB is already at head.
+          command:
+            - alembic
+            - "-c"
+            - alembic.ini
+            - upgrade
+            - head
+          envFrom:
+            - secretRef:
+                name: claude-bridge-migrate-secrets
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 32Mi

--- a/apps/automation/claude-bridge/networkpolicy.yaml
+++ b/apps/automation/claude-bridge/networkpolicy.yaml
@@ -1,0 +1,86 @@
+---
+# Defense-in-depth at the network layer. The bridge already enforces
+# per-request API key auth; this policy reduces blast radius if a future
+# code bug or compromised dependency tries to reach somewhere it should
+# not (lateral movement, exfil to a non-Discord host, etc.).
+#
+# Rules:
+#   Ingress:
+#     - From anywhere on 8080 (LB clients are external LAN hooks; the
+#       app layer enforces X-API-Key, so network ACLs are belt+braces).
+#     - From kube-prometheus-stack on 8080 for future ServiceMonitor
+#       scraping (no-op until /metrics is added in a follow-up unit).
+#   Egress:
+#     - DNS to kube-system (UDP 53) for resolving discord.com and the
+#       Postgres hostname (if the DSN ever uses one instead of an IP).
+#     - Postgres at 192.168.1.123:5432 only.
+#     - TCP 443 to the internet, excluding RFC1918 and cluster CIDRs,
+#       for Discord Gateway WebSocket + REST API.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: claude-bridge
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+spec:
+  podSelector:
+    matchLabels:
+      app: claude-bridge
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+      # No `from:` block means "from anywhere" (intra-cluster + external
+      # LB clients). The app-layer X-API-Key check is the real gate; this
+      # is the broadest the policy can be while still imposing a
+      # protocol/port constraint.
+  egress:
+    # DNS resolution. Some clusters run kube-dns under a different label;
+    # using namespaceSelector + portSelector covers the common cases
+    # without hardcoding a service IP.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Postgres on the homelab Postgres host (TimescaleDB at 192.168.1.123).
+    # Single /32 CIDR keeps the rule auditable: any future Postgres move
+    # must update this manifest.
+    - to:
+        - ipBlock:
+            cidr: 192.168.1.123/32
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Discord Gateway WS + REST API. Discord publishes a CIDR list but
+    # rotates it; allowing TCP 443 to the public internet (with
+    # internal ranges excluded) is the standard workaround. The bridge
+    # only initiates TLS to gateway.discord.gg + discord.com, so the
+    # blast radius is the API key + bot token, both already managed.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              # RFC1918
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              # Link-local + multicast + reserved
+              - 169.254.0.0/16
+              - 224.0.0.0/4
+              - 240.0.0.0/4
+              # Loopback-ish (defensive, would never originate from a
+              # pod, but the explicit deny keeps the rule explicit).
+              - 127.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443

--- a/apps/automation/claude-bridge/pdb.yaml
+++ b/apps/automation/claude-bridge/pdb.yaml
@@ -1,0 +1,16 @@
+---
+# minAvailable: 1 means the cluster will never voluntarily evict the
+# single bridge pod (drain, autoscaler) before it has a replacement.
+# Combined with priorityClassName: system-cluster-critical on the
+# Deployment, this gives both voluntary (PDB) and involuntary (kubelet
+# eviction) protection.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: claude-bridge
+  namespace: automation
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: claude-bridge

--- a/apps/automation/claude-bridge/prometheus-rules.yaml
+++ b/apps/automation/claude-bridge/prometheus-rules.yaml
@@ -1,0 +1,116 @@
+---
+# Infrastructure-level alerts. Application-level alerts (e.g.,
+# allowlist anomalies, Tier 3 approval rate spikes) require the
+# /metrics endpoint that ships in a follow-up unit; rules for those
+# will be added then.
+#
+# All rules carry `severity: critical` or `warning`. The
+# discord-alert-proxy themed-embed router uses severity to pick the
+# Balrog (red, critical) or Star Wars (orange, warning) embed.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: claude-bridge-alerts
+  namespace: automation
+  labels:
+    # `release: kube-prometheus-stack` is the discovery selector
+    # configured in the kube-prometheus-stack values. Without it,
+    # Prometheus does not pick up the rule.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: claude-bridge-alerts
+    app.kubernetes.io/part-of: automation
+spec:
+  groups:
+    - name: claude-bridge-availability
+      rules:
+        - alert: ClaudeBridgeDown
+          # Single-replica deployment: zero ready pods means the bridge
+          # is fully offline and Tier 3 actions cannot be approved or
+          # denied. Hooks fail-closed in this state, but operators need
+          # to know quickly.
+          expr: |
+            kube_deployment_status_replicas_available{
+              namespace="automation",
+              deployment="claude-bridge"
+            } == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: claude-bridge
+          annotations:
+            summary: "claude-bridge has no ready replicas"
+            description: |
+              The claude-bridge deployment in namespace automation has
+              had 0 ready replicas for 5 minutes. Tier 3 approvals are
+              unavailable; hooks fall back to hard-block (deny). Check
+              `kubectl -n automation describe pod -l app=claude-bridge`.
+        - alert: ClaudeBridgePodCrashLooping
+          # >0.1 restarts/sec averaged over 10min = roughly one restart
+          # per ~10s, which indicates a stuck crash loop rather than a
+          # graceful redeploy.
+          expr: |
+            rate(kube_pod_container_status_restarts_total{
+              namespace="automation",
+              container="bridge"
+            }[10m]) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+            component: claude-bridge
+          annotations:
+            summary: "claude-bridge container is crash-looping"
+            description: |
+              The claude-bridge container has restarted >0.1 times/sec
+              over the last 10 minutes. Likely causes: misconfigured
+              env (missing HMAC current secret, bad postgres DSN), or
+              startup probe failing (Discord Gateway login).
+              Check `kubectl -n automation logs -l app=claude-bridge --previous`.
+        - alert: ClaudeBridgeMigrationFailed
+          # PreSync alembic job has failed (1+ failed pods). Sync is
+          # blocked until the migration succeeds, so the operator must
+          # triage. Schema regressions or DB outages surface here.
+          expr: |
+            kube_job_status_failed{
+              namespace="automation",
+              job_name=~"claude-bridge-migrate.*"
+            } > 0
+          for: 1m
+          labels:
+            severity: critical
+            component: claude-bridge
+          annotations:
+            summary: "claude-bridge alembic migration failed"
+            description: |
+              The PreSync alembic migration job in namespace automation
+              reported a failed pod. ArgoCD has blocked the sync; the
+              previous bridge revision continues serving the old schema.
+              Check `kubectl -n automation logs job/{{ $labels.job_name }}`
+              and confirm the migrate-role DSN + DB reachability.
+    - name: claude-bridge-readiness
+      rules:
+        - alert: ClaudeBridgeNotReady
+          # Single replica + readinessProbe failing means /readyz is
+          # 503-ing: either Discord Gateway is not connected or the
+          # Postgres pool probe is failing. Different from ClaudeBridgeDown
+          # because the pod is still up; the LB has just pulled it from
+          # rotation and external callers see connection refused.
+          expr: |
+            kube_deployment_status_replicas{
+              namespace="automation",
+              deployment="claude-bridge"
+            } > 0
+            and
+            kube_deployment_status_replicas_available{
+              namespace="automation",
+              deployment="claude-bridge"
+            } == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: claude-bridge
+          annotations:
+            summary: "claude-bridge pod is running but not ready"
+            description: |
+              claude-bridge has a running pod but /readyz is failing.
+              Likely: Postgres pool degraded or Discord Gateway
+              disconnected. Inspect the pod's /readyz response and logs.

--- a/apps/automation/claude-bridge/service.yaml
+++ b/apps/automation/claude-bridge/service.yaml
@@ -1,0 +1,34 @@
+---
+# LoadBalancer (not ClusterIP) because POST /notify is called from
+# outside the cluster (operator workstations + future remote agents).
+# MetalLB hands out 192.168.1.227 via L2 advertisement; pool range is
+# 192.168.1.225-240 (see infrastructure/metallb/values.yaml).
+#
+# Operator hooks should use http://192.168.1.227:8080 (or a DNS record
+# pointing at this IP) for CLAUDE_BRIDGE_URL after deploy.
+apiVersion: v1
+kind: Service
+metadata:
+  name: claude-bridge
+  namespace: automation
+  labels:
+    app: claude-bridge
+    app.kubernetes.io/name: claude-bridge
+    app.kubernetes.io/component: hitl-bridge
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 192.168.1.227
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.227
+  # externalTrafficPolicy: Local preserves the client source IP for the
+  # bridge's audit log. Combined with single-replica + recreate strategy,
+  # this means LB traffic only routes to the node hosting the live pod;
+  # MetalLB L2 mode handles the failover when the pod moves.
+  externalTrafficPolicy: Local
+  selector:
+    app: claude-bridge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/apps/automation/kustomization.yaml
+++ b/apps/automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: automation
+resources:
+  - automation-namespace.yaml
+  - claude-bridge/

--- a/environments/dev/kustomization.yaml
+++ b/environments/dev/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ../../apps/media
   - ../../apps/dashboard
   - ../../apps/science
+  - ../../apps/automation


### PR DESCRIPTION
## Summary

Deploys the HITL Discord approval bridge (`claude-bridge`) to the dev cluster as a single-replica K8s workload in a new `automation` namespace. Closes Phase 1 Unit 10 of the [bridge plan](docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md).

- New namespace `automation` (PSS restricted) for autonomous-agent control-plane workloads
- Single replica (Gateway constraint), Recreate strategy, LoadBalancer 192.168.1.227 (MetalLB)
- Secrets sourced from 1Password via ESO (onepassword-infrastructure ClusterSecretStore), addressed by item ID
- PreSync alembic Job catches the live DB up from `0001_initial` to head
- NetworkPolicy locks egress to kube-dns, 192.168.1.123:5432, and 0.0.0.0/0:443 (except RFC1918)

## Resources

| Kind | Name | Notes |
|---|---|---|
| Namespace | `automation` | PSS restricted enforce + audit + warn |
| Deployment | `claude-bridge` | UID 10001, RO root, /healthz + /readyz, startupProbe (60s budget) |
| Service | `claude-bridge` | LoadBalancer 192.168.1.227, externalTrafficPolicy Local |
| PDB | `claude-bridge` | minAvailable 1 |
| ConfigMap | `claude-bridge-config` | Guild + 4 channel IDs, log level |
| ExternalSecret | `claude-bridge-secrets` | 7 keys: bot token, allowlist, HMAC current/previous, 2 API key pools, app DSN |
| ExternalSecret | `claude-bridge-migrate-secrets` | migrate-role DSN only (DDL-capable, never on the request path) |
| Job | `claude-bridge-migrate` | PreSync hook, alembic upgrade head |
| NetworkPolicy | `claude-bridge` | Default-deny, narrow egress |
| PrometheusRule | `claude-bridge-alerts` | 4 alerts (down, not-ready, crash-looping, migration-failed) |

## 1Password items (Infrastructure vault)

All ESO `remoteRef.key` values use `<item-id>/<field>` (matching the existing discord-alert-proxy convention).

| Title | Item ID | Fields |
|---|---|---|
| `claude-bridge/discord-bot-token` | `rtdvrnr6emcan2tgqa4ctpr4qi` | `token` |
| `claude-bridge/server-hmac-secret` | `gwlimgxxn2uzul7pdfmkzairki` | `current`, `previous` |
| `claude-bridge/api-key-local-hook` | `67oqrbim2quqtx3jqz54h23wfi` | `keys` (JSON array) |
| `claude-bridge/api-key-remote-agent` | `t4o74mhjfvhyhag354taybi23i` | `keys` (JSON array) |
| `claude-bridge/allowlist` | `adt3c6cuittlebov2lod7pxilq` | `user_ids` (JSON array) |
| `claude-bridge/postgres-dsn` | `wvdgy2x2r7wqgy2oot2wmuqdci` | `dsn`, `migrate_dsn` |

The two PG password items (`PostgreSQL Claude Bridge App`, `PostgreSQL Claude Bridge Migrate`) preexist from the ansible postgres role.

## Pre-merge state

- All 1P items populated with real values
- Both DSNs verified to authenticate against 192.168.1.123 (app + migrate roles)
- pg_hba already has narrow rules for `claude_bridge` database from `10.244.0.0/16` (managed in `ansible-quasarlab/roles/postgresql`)
- Kustomize renders cleanly for the dev environment

## Operator handoff (after merge)

1. Operator workstation: change `~/.claude/hooks/.env` to point at the cluster:
   ```
   CLAUDE_BRIDGE_URL=http://192.168.1.227:8080
   ```
   Leave `CLAUDE_BRIDGE_HOOK=hard` until the first sync confirms the bridge is healthy, then flip to `polling`.
2. Watch ArgoCD sync the `dev` Application. Expected order: Namespace, Job (PreSync hook applies migrations 0002 + 0003), then Deployment + others.
3. Confirm `/healthz` and `/readyz` both return 200 from `192.168.1.227:8080`, and `/readyz` does not regress on Postgres or Discord Gateway.
4. Verify the bot appears online in the QuasarLab guild and `/status <action_id>` responds (with "unknown action" since none have been issued yet).

## Deferred follow-ups

- ServiceMonitor + `/metrics` endpoint (no metrics shipped yet, would scrape nothing)
- Application-level alerts (allowlist anomaly, approval-rate spikes) once `/metrics` lands
- TLS termination at the LB (today HTTP over trusted LAN, matches existing discord-alert-proxy posture)
- Multi-replica with leader election (current single-replica is the documented Gateway constraint)

## Test plan

- [x] `kubectl kustomize apps/automation/claude-bridge/` renders without errors
- [x] `kubectl kustomize environments/dev/` renders without errors
- [x] PG DSNs probed against the live DB (both roles authenticate, claude_bridge DB exists)
- [x] All 7 secret keys + the migrate DSN map to populated 1P fields
- [ ] ArgoCD dev sync completes (PreSync Job succeeds, Deployment becomes ready)
- [ ] Bot appears online; `/approve`, `/deny`, `/status`, `/undo` register as guild commands
- [ ] Local hook against the deployed bridge: `CLAUDE_BRIDGE_HOOK=polling` end-to-end approval flow