### PR TITLE
chore(claude-bridge): bump image SHA to e953f0fa4e3e

### DIFF
--- a/apps/automation/claude-bridge/deployment.yaml
+++ b/apps/automation/claude-bridge/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           # claude-bridge CI on merges to main. Operator bumps this line
           # via PR after a tested image is published. Same convention as
           # discord-alert-proxy (image: ghcr.io/.../discord-alert-proxy:<sha>).
-          image: ghcr.io/mithr4ndir/claude-bridge:11c71d3f5437
+          image: ghcr.io/mithr4ndir/claude-bridge:e953f0fa4e3e
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/automation/claude-bridge/migration-job.yaml
+++ b/apps/automation/claude-bridge/migration-job.yaml
@@ -68,7 +68,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: alembic
-          image: ghcr.io/mithr4ndir/claude-bridge:11c71d3f5437
+          image: ghcr.io/mithr4ndir/claude-bridge:e953f0fa4e3e
           imagePullPolicy: IfNotPresent
           # alembic.ini reads sqlalchemy.url from CLAUDE_BRIDGE_MIGRATE_DSN
           # via a ConfigParser interpolation override in env.py (Unit 3).


### PR DESCRIPTION
## Summary

Picks up [claude-bridge PR #28](https://github.com/mithr4ndir/claude-bridge/pull/28) which copies \`alembic.ini\` into the runtime image. Without this bump, the migration Job under sync-wave \`-1\` keeps failing with \"No 'script_location' key found in configuration\" and ArgoCD never progresses past wave \`-1\` to roll the Deployment.

Same SHA goes into both \`deployment.yaml\` and \`migration-job.yaml\` (single-image convention from Unit 10).

Verified \`ghcr.io/mithr4ndir/claude-bridge:e953f0fa4e3e\` is anonymously pullable.

## Test plan

- [x] Kustomize renders cleanly
- [ ] After merge, ArgoCD picks up new SHA, migration Job runs alembic 0002 + 0003, Deployment rolls out