### PR TITLE
chore(claude-bridge): bump image SHA to f2c1854886da

### DIFF
--- a/apps/automation/claude-bridge/deployment.yaml
+++ b/apps/automation/claude-bridge/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           # claude-bridge CI on merges to main. Operator bumps this line
           # via PR after a tested image is published. Same convention as
           # discord-alert-proxy (image: ghcr.io/.../discord-alert-proxy:<sha>).
-          image: ghcr.io/mithr4ndir/claude-bridge:e953f0fa4e3e
+          image: ghcr.io/mithr4ndir/claude-bridge:f2c1854886da
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/automation/claude-bridge/migration-job.yaml
+++ b/apps/automation/claude-bridge/migration-job.yaml
@@ -68,7 +68,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: alembic
-          image: ghcr.io/mithr4ndir/claude-bridge:e953f0fa4e3e
+          image: ghcr.io/mithr4ndir/claude-bridge:f2c1854886da
           imagePullPolicy: IfNotPresent
           # alembic.ini reads sqlalchemy.url from CLAUDE_BRIDGE_MIGRATE_DSN
           # via a ConfigParser interpolation override in env.py (Unit 3).


### PR DESCRIPTION
Picks up claude-bridge PR #29 (escape `%` in CLAUDE_BRIDGE_MIGRATE_DSN before alembic.config.set_main_option). Second bump on the Unit 10 deploy chain. After this lands the migration Job should clear and waves 0 should roll the Deployment.