### PR TITLE
fix(claude-bridge): drop deprecated spec.loadBalancerIP

### DIFF
--- a/apps/automation/claude-bridge/service.yaml
+++ b/apps/automation/claude-bridge/service.yaml
@@ -19,7 +19,6 @@ metadata:
     metallb.universe.tf/loadBalancerIPs: 192.168.1.227
 spec:
   type: LoadBalancer
-  loadBalancerIP: 192.168.1.227
   # externalTrafficPolicy: Local preserves the client source IP for the
   # bridge's audit log. Combined with single-replica + recreate strategy,
   # this means LB traffic only routes to the node hosting the live pod;


### PR DESCRIPTION
MetalLB 0.13+ rejects services that set both `metallb.universe.tf/loadBalancerIPs` annotation AND `spec.loadBalancerIP`. Annotation is the supported form. Drops the spec field so MetalLB can allocate 192.168.1.227.