### PR TITLE
chore(claude-bridge): bump image SHA to 1b30d218a072

### DIFF
--- a/apps/automation/claude-bridge/deployment.yaml
+++ b/apps/automation/claude-bridge/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           # claude-bridge CI on merges to main. Operator bumps this line
           # via PR after a tested image is published. Same convention as
           # discord-alert-proxy (image: ghcr.io/.../discord-alert-proxy:<sha>).
-          image: ghcr.io/mithr4ndir/claude-bridge:f2c1854886da
+          image: ghcr.io/mithr4ndir/claude-bridge:1b30d218a072
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/automation/claude-bridge/migration-job.yaml
+++ b/apps/automation/claude-bridge/migration-job.yaml
@@ -68,7 +68,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: alembic
-          image: ghcr.io/mithr4ndir/claude-bridge:f2c1854886da
+          image: ghcr.io/mithr4ndir/claude-bridge:1b30d218a072
           imagePullPolicy: IfNotPresent
           # alembic.ini reads sqlalchemy.url from CLAUDE_BRIDGE_MIGRATE_DSN
           # via a ConfigParser interpolation override in env.py (Unit 3).


### PR DESCRIPTION
Picks up claude-bridge PR #30 (drop manage_guild requirement from slash commands).