### PR TITLE
feat(grafana): add All Updates stat panel for apt_upgrades_pending_total

### DIFF
--- a/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-vms-quasarlab-overview.yaml
+++ b/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-vms-quasarlab-overview.yaml
@@ -270,10 +270,10 @@ data:
         {
           "id": 6,
           "type": "stat",
-          "title": "Pending Security Updates",
+          "title": "Security Updates",
           "gridPos": {
             "h": 4,
-            "w": 4,
+            "w": 2,
             "x": 16,
             "y": 1
           },
@@ -307,6 +307,63 @@ data:
                   {
                     "color": "orange",
                     "value": 5
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "background",
+            "textMode": "value"
+          }
+        },
+        {
+          "id": 100,
+          "type": "stat",
+          "title": "All Updates",
+          "description": "Total pending apt upgrades across all repos including third-party (Kubernetes, HashiCorp, Vector, Wazuh, etc.). Mirrors the count surfaced by the MOTD apt-check on SSH login.",
+          "gridPos": {
+            "h": 4,
+            "w": 2,
+            "x": 18,
+            "y": 1
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "targets": [
+            {
+              "expr": "sum(apt_upgrades_pending_total{job=\"vm-node-exporter\"}) or vector(0)",
+              "legendFormat": "",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "blue",
+                    "value": 1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 20
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

Adds a sibling stat panel "All Updates" next to the existing "Security Updates" panel in the VMs Quasarlab Overview dashboard. The new panel queries the `apt_upgrades_pending_total` gauge that mithr4ndir/ansible-quasarlab#128 is adding to the unattended_upgrades role.

## Why

The existing "Pending Security Updates" panel uses `unattended_upgrades_pending_security`, which only counts the Ubuntu/Debian `-security` pocket. Hosts running third-party repos (Kubernetes, HashiCorp, Vector, Wazuh) routinely have pending upgrades that are NOT classified as security and so the panel stays at 0 even when SSH login MOTD shows multiple updates pending. This gives a false sense of "everything is patched" when there are actually outstanding upgrades.

The new panel surfaces the total alongside the security-only count so both signals are visible.

## Layout

The existing security panel was 4 cells wide; shrunk to 2 (`w:4 -> w:2`) and renamed `Pending Security Updates -> Security Updates` so the new panel can fit beside it at `x:18, w:2`. No other panels were moved.

Threshold scheme on the new panel is informational (green at 0, blue at >=1) rather than alarming, because non-security pending upgrades are not urgent. Yellow at >=20 flags a large backlog worth scheduling.

## Dependencies

- ansible-quasarlab#128 must be merged before the panel will render data
- `unattended_upgrades` role must be re-applied to the fleet after #128 lands so the new gauge is exposed by node_exporter

## Test plan

- [x] YAML structure validates: `python3 -c "yaml.safe_load(open(...))"` succeeds
- [x] Embedded dashboard JSON validates: `json.loads(...)` succeeds; panel count went from 14 to 15
- [x] On command-center1 (where the gauge is already live from a manual hot-patch), `apt_upgrades_pending_total = 4` is exposed at `:9100/metrics`
- [ ] After merge + ArgoCD sync, verify the panel loads in Grafana and shows the expected number
- [ ] After ansible-quasarlab#128 is applied fleet-wide, verify the panel sums correctly across all VMs