### PR TITLE
chore(claude-bridge): temporarily disable while 1P items are reconciled

### DIFF
--- a/apps/automation/kustomization.yaml
+++ b/apps/automation/kustomization.yaml
@@ -3,4 +3,10 @@ kind: Kustomization
 namespace: automation
 resources:
   - automation-namespace.yaml
-  - claude-bridge/
+  # claude-bridge temporarily disabled (2026-05-06) while 1P backing items
+  # are sorted out. ExternalSecret retries against missing items were
+  # piling on 429s during a cap-exhausted window. Re-enable once Unit 10
+  # 1P items (token, hmac current/previous, allowlist user_ids,
+  # api-key-local-hook, api-key-remote-agent, postgres dsn/migrate_dsn)
+  # are validated in the Infrastructure vault.
+  # - claude-bridge/


### PR DESCRIPTION
## Summary
- Comments out the `claude-bridge/` resource ref in `apps/automation/kustomization.yaml` so ArgoCD prunes the Deployment, ExternalSecrets, Service, PDB, NetworkPolicy, ConfigMap, PrometheusRule, and migration job.
- ExternalSecret `deletionPolicy: Retain` means the downstream Secret objects survive the prune for the next bring-up, no data loss.
- Block comment in the kustomization spells out the re-enable preconditions (Unit 10 1P items must exist and be valid).

## Why
- 2026-05-06: 1P account `read_write` cap was 1000/1000 with 19h to reset. Two compounding causes:
  1. `ansible-proxmox.timer` and `ansible-security.timer` had been re-enabled despite the 05-02 runbook saying keep them stopped until Phase 1 vault rollout was end-to-end validated. Already disabled out-of-band.
  2. `claude-bridge-secrets` and `claude-bridge-migrate-secrets` were `SecretSyncedError`, retry-looping into 1P (~28 errors/h, 429s only). Those Unit 10 1P items were planned to be created when Unit 10 lands, but the cluster manifests landed first.
- The bridge service itself was running healthy on a stale Secret from a previous successful sync. Turning it down per request while we revisit the 1P side properly.

## Test plan
- [ ] Verify ArgoCD `dev` app sync succeeds and prunes the bridge resources cleanly.
- [ ] Confirm ESO no longer logs `rate limit exceeded` errors for `claude-bridge-*` ExternalSecrets after sync.
- [ ] Confirm `automation` namespace still healthy (only `automation-namespace.yaml` rendered there now).
- [ ] After 1P cap recovers, verify `op service-account ratelimit` shows `account/read_write REMAINING > 0` before re-enabling timers or the bridge.

## When to revert
Uncomment the `- claude-bridge/` line once these 1P items in the Infrastructure vault are validated by the bridge runbook:
- `claude-bridge/discord-bot-token`
- `claude-bridge/server-hmac-secret` (current + previous fields)
- `claude-bridge/postgres-dsn` (dsn + migrate_dsn fields)
- `claude-bridge/api-key-local-hook`
- `claude-bridge/api-key-remote-agent`
- `claude-bridge/allowlist` (user_ids field)