### PR TITLE
feat(monitoring): add SNMP exporter for managed switch monitoring

### DIFF
--- a/infrastructure/monitoring/application.yaml
+++ b/infrastructure/monitoring/application.yaml
@@ -106,3 +106,30 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snmp-exporter
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mithr4ndir/k8s-argocd.git
+    targetRevision: HEAD
+    path: infrastructure/monitoring/snmp-exporter
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-network-snmp-switch.yaml
+++ b/infrastructure/monitoring/grafana-dashboards/grafana-dashboard-network-snmp-switch.yaml
@@ -1,0 +1,490 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-network-snmp-switch
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Network"
+data:
+  network-snmp-switch.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 100,
+          "panels": [],
+          "title": "Switch Overview",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              }
+            }
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "value_and_name"
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "up{job=\"snmp-switch\", instance=~\"$instance\"}",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Reachable",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "blue", "value": null }
+                ]
+              },
+              "unit": "s"
+            }
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "value"
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "sysUpTime{job=\"snmp-switch\", instance=~\"$instance\"} / 100",
+              "legendFormat": "uptime",
+              "refId": "A"
+            }
+          ],
+          "title": "Uptime",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              }
+            }
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "value"
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "count(ifOperStatus{job=\"snmp-switch\", instance=~\"$instance\", ifOperStatus=\"1\"})",
+              "legendFormat": "ports up",
+              "refId": "A"
+            }
+          ],
+          "title": "Ports Up",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            }
+          },
+          "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+          "id": 4,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "value"
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "sum(rate(ifInErrors{job=\"snmp-switch\", instance=~\"$instance\"}[5m]) + rate(ifOutErrors{job=\"snmp-switch\", instance=~\"$instance\"}[5m]))",
+              "legendFormat": "errors/s",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Errors/s",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+          "id": 101,
+          "panels": [],
+          "title": "Per-Port Status",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": true
+              },
+              "mappings": [
+                { "options": { "1": { "color": "green", "index": 0, "text": "up" } }, "type": "value" },
+                { "options": { "2": { "color": "red", "index": 1, "text": "down" } }, "type": "value" },
+                { "options": { "3": { "color": "yellow", "index": 2, "text": "testing" } }, "type": "value" },
+                { "options": { "4": { "color": "yellow", "index": 3, "text": "unknown" } }, "type": "value" },
+                { "options": { "5": { "color": "gray", "index": 4, "text": "dormant" } }, "type": "value" },
+                { "options": { "6": { "color": "gray", "index": 5, "text": "notPresent" } }, "type": "value" },
+                { "options": { "7": { "color": "yellow", "index": 6, "text": "lowerLayerDown" } }, "type": "value" }
+              ],
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+            }
+          },
+          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 6 },
+          "id": 5,
+          "options": {
+            "showHeader": true,
+            "footer": { "show": false }
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "ifOperStatus{job=\"snmp-switch\", instance=~\"$instance\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Port Status",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true, "__name__": true, "job": true, "device_type": true, "vendor": true, "model": true },
+                "indexByName": {},
+                "renameByName": { "Value": "status", "ifName": "port", "ifAlias": "alias" }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+          "id": 102,
+          "panels": [],
+          "title": "Traffic",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "bps"
+            }
+          },
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 17 },
+          "id": 6,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifHCInOctets{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m]) * 8",
+              "legendFormat": "{{ifName}} ({{ifAlias}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Inbound (bits/sec)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "bps"
+            }
+          },
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 17 },
+          "id": 7,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifHCOutOctets{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m]) * 8",
+              "legendFormat": "{{ifName}} ({{ifAlias}})",
+              "refId": "A"
+            }
+          ],
+          "title": "Outbound (bits/sec)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+          "id": 103,
+          "panels": [],
+          "title": "Errors and Discards",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "unit": "pps"
+            }
+          },
+          "gridPos": { "h": 9, "w": 12, "x": 0, "y": 27 },
+          "id": 8,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifInErrors{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m])",
+              "legendFormat": "in: {{ifName}} ({{ifAlias}})",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifOutErrors{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m])",
+              "legendFormat": "out: {{ifName}} ({{ifAlias}})",
+              "refId": "B"
+            }
+          ],
+          "title": "Errors per Port",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "unit": "pps"
+            }
+          },
+          "gridPos": { "h": 9, "w": 12, "x": 12, "y": 27 },
+          "id": 9,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi" }
+          },
+          "pluginVersion": "12.4.1",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifInDiscards{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m])",
+              "legendFormat": "in: {{ifName}} ({{ifAlias}})",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "rate(ifOutDiscards{job=\"snmp-switch\", instance=~\"$instance\", ifName=~\"$port\"}[5m])",
+              "legendFormat": "out: {{ifName}} ({{ifAlias}})",
+              "refId": "B"
+            }
+          ],
+          "title": "Discards per Port",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["network", "snmp", "switch", "tplink"],
+      "templating": {
+        "list": [
+          {
+            "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "definition": "label_values(up{job=\"snmp-switch\"}, instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Switch",
+            "multi": true,
+            "name": "instance",
+            "options": [],
+            "query": { "query": "label_values(up{job=\"snmp-switch\"}, instance)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "datasource": { "type": "prometheus", "uid": "${datasource}" },
+            "definition": "label_values(ifOperStatus{job=\"snmp-switch\", instance=~\"$instance\"}, ifName)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Port",
+            "multi": true,
+            "name": "port",
+            "options": [],
+            "query": { "query": "label_values(ifOperStatus{job=\"snmp-switch\", instance=~\"$instance\"}, ifName)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": { "from": "now-3h", "to": "now" },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Network / SNMP Switch",
+      "uid": "network-snmp-switch",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/infrastructure/monitoring/grafana-dashboards/kustomization.yaml
+++ b/infrastructure/monitoring/grafana-dashboards/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - grafana-dashboard-kubernetes-node-metrics.yaml
   - grafana-dashboard-kubernetes-pod-metrics.yaml
   - grafana-dashboard-kubernetes-workloads.yaml
+  - grafana-dashboard-network-snmp-switch.yaml
   - grafana-dashboard-proxmox-cluster-overview.yaml
   - grafana-dashboard-proxmox-nodes-overview.yaml
   - grafana-dashboard-proxmox-storage-metrics.yaml

--- a/infrastructure/monitoring/kube-prometheus-stack/values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/values.yaml
@@ -23,6 +23,26 @@ kube-prometheus-stack:
             - files:
                 - /etc/prometheus/file_sd/vm-targets.json
               refresh_interval: 1m
+        - job_name: 'snmp-switch'
+          metrics_path: /snmp
+          params:
+            module: [if_mib]
+            auth: [switch_v2c]
+          static_configs:
+            - targets:
+                - '192.168.1.2'
+              labels:
+                instance: 'lab-sw01'
+                device_type: 'switch'
+                vendor: 'tplink'
+                model: 'TL-SG2016P'
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __param_target
+            - source_labels: [__param_target]
+              target_label: instance
+            - target_label: __address__
+              replacement: snmp-exporter-prometheus-snmp-exporter.monitoring.svc.cluster.local:9116
       volumes:
         - name: file-sd-targets
           configMap:
@@ -663,6 +683,55 @@ kube-prometheus-stack:
               annotations:
                 summary: "Security enforcement hasn't run in over 1 hour on {{ $labels.instance }}"
                 description: "Last security timer run was {{ $value | humanizeDuration }} ago on {{ $labels.instance }}. Wazuh/CrowdSec config enforcement is not converging."
+
+    snmp-network-alerts:
+      groups:
+        - name: snmp-availability
+          rules:
+            - alert: SnmpExporterDown
+              expr: up{job="snmp-switch"} == 0
+              for: 3m
+              labels:
+                severity: critical
+              annotations:
+                summary: "SNMP scrape of {{ $labels.instance }} failing"
+                description: "Prometheus has been unable to scrape SNMP target {{ $labels.instance }} for 3 minutes. Either snmp-exporter is down or the device is unreachable. Check `kubectl -n monitoring logs deploy/snmp-exporter-prometheus-snmp-exporter` and ping the target."
+        - name: snmp-link-status
+          rules:
+            - alert: SwitchUplinkDown
+              expr: ifOperStatus{job="snmp-switch", ifAlias=~"(?i).*(uplink|pfsense|wan).*"} != 1
+              for: 1m
+              labels:
+                severity: critical
+              annotations:
+                summary: "Switch uplink {{ $labels.ifName }} on {{ $labels.instance }} is down"
+                description: "Interface {{ $labels.ifName }} (alias '{{ $labels.ifAlias }}') has ifOperStatus != up for 1 minute. The switch's path to pfSense is broken. Check cable and pfSense LAN port status."
+            - alert: SwitchPortDown
+              expr: ifOperStatus{job="snmp-switch", ifAdminStatus="1"} == 2
+              for: 5m
+              labels:
+                severity: warning
+              annotations:
+                summary: "Switch port {{ $labels.ifName }} on {{ $labels.instance }} is down"
+                description: "Interface {{ $labels.ifName }} (alias '{{ $labels.ifAlias }}') is administratively up but operationally down for 5 minutes. Cable, link partner, or speed/duplex mismatch."
+        - name: snmp-link-quality
+          rules:
+            - alert: SwitchInterfaceErrors
+              expr: rate(ifInErrors{job="snmp-switch"}[5m]) + rate(ifOutErrors{job="snmp-switch"}[5m]) > 1
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "Errors on {{ $labels.instance }} interface {{ $labels.ifName }}"
+                description: "Interface {{ $labels.ifName }} (alias '{{ $labels.ifAlias }}') is seeing >1 packet error/sec for 10m. Likely cable, SFP, or duplex problem."
+            - alert: SwitchInterfaceDiscards
+              expr: rate(ifInDiscards{job="snmp-switch"}[5m]) + rate(ifOutDiscards{job="snmp-switch"}[5m]) > 10
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "Packet discards on {{ $labels.instance }} interface {{ $labels.ifName }}"
+                description: "Interface {{ $labels.ifName }} (alias '{{ $labels.ifAlias }}') is discarding >10 packets/sec for 10m. Either congestion or buffer exhaustion."
 
     media-service-health:
       groups:

--- a/infrastructure/monitoring/kustomization.yaml
+++ b/infrastructure/monitoring/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - vector-aggregator-svc.yaml
   - grafana-externalsecret.yaml
   - healthchecks-watchdog-externalsecret.yaml
+  - snmp-exporter-externalsecret.yaml
   - grafana-dashboards
   - discord-alert-proxy

--- a/infrastructure/monitoring/snmp-exporter-externalsecret.yaml
+++ b/infrastructure/monitoring/snmp-exporter-externalsecret.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: snmp-exporter-config
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword-infrastructure
+    kind: ClusterSecretStore
+  target:
+    name: snmp-exporter-config
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        snmp.yml: |
+          auths:
+            switch_v2c:
+              version: 2
+              community: "{{ .community }}"
+          modules:
+            if_mib:
+              walk:
+                - sysUpTime
+                - interfaces
+                - ifXTable
+              lookups:
+                - source_indexes: [ifIndex]
+                  lookup: ifAlias
+                - source_indexes: [ifIndex]
+                  lookup: ifDescr
+                - source_indexes: [ifIndex]
+                  lookup: ifName
+              overrides:
+                ifAlias:
+                  ignore: true
+                ifDescr:
+                  ignore: true
+                ifName:
+                  type: DisplayString
+                ifType:
+                  type: EnumAsInfo
+  data:
+    - secretKey: community
+      remoteRef:
+        key: "ie2ggejxa6kfepuhxdvggvsymm/community"
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/infrastructure/monitoring/snmp-exporter/Chart.lock
+++ b/infrastructure/monitoring/snmp-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-snmp-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 9.14.0
+digest: sha256:addf43715ed2629dd11ce808a8314d41248b46b214c22cab7f172ad9339a27d4
+generated: "2026-05-08T01:52:02.062334025Z"

--- a/infrastructure/monitoring/snmp-exporter/Chart.yaml
+++ b/infrastructure/monitoring/snmp-exporter/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: snmp-exporter
+version: 1.0.0
+description: SNMP exporter for the QuasarLab managed switch (TL-SG2016P) and other SNMP devices
+dependencies:
+  - name: prometheus-snmp-exporter
+    version: "9.14.0"
+    repository: https://prometheus-community.github.io/helm-charts

--- a/infrastructure/monitoring/snmp-exporter/values.yaml
+++ b/infrastructure/monitoring/snmp-exporter/values.yaml
@@ -1,0 +1,30 @@
+prometheus-snmp-exporter:
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+
+  service:
+    type: ClusterIP
+    port: 9116
+
+  serviceMonitor:
+    enabled: false
+
+  extraArgs:
+    - --config.file=/etc/snmp_exporter/snmp.yml
+
+  extraSecretMounts:
+    - name: snmp-exporter-config
+      mountPath: /etc/snmp_exporter/snmp.yml
+      subPath: snmp.yml
+      secretName: snmp-exporter-config
+      readOnly: true
+      defaultMode: 420
+
+  podAnnotations:
+    reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary

Wires the new **TL-SG2016P managed switch (192.168.1.2 / lab-sw01)** into the existing Prometheus + Grafana stack so that port traffic, errors, discards, link state, and uptime are observable, and link or scrape loss pages.

This is the K8s side of the lab switch deployment that landed today. The switch is already on the LAN as the new LAN core (replaced the wifi-router-as-switch).

## Architecture

- **Helm-deployed** `prometheus-snmp-exporter` (chart 9.14.0, snmp_exporter v0.30.1) in the `monitoring` namespace, behind ClusterIP service.
- **`snmp.yml` is rendered by ESO templating** from a 1Password Secret and mounted into the exporter pod at `/etc/snmp_exporter/snmp.yml`. The SNMP v2c community string never lives in git.
- **Prometheus** `additionalScrapeConfigs` adds job `snmp-switch` pointing at the in-cluster exporter Service.
- **Alerts** for: SNMP scrape down, uplink down (matched by `ifAlias =~ "(?i).*(uplink|pfsense|wan).*"`), generic port down, and rising error / discard rates.
- **Grafana dashboard** "Network / SNMP Switch" under the Network folder, with `instance` (switch) and `port` multi-select variables and panels for status, traffic, errors, and discards.

## File changes

```
NEW infrastructure/monitoring/snmp-exporter/Chart.yaml
NEW infrastructure/monitoring/snmp-exporter/Chart.lock
NEW infrastructure/monitoring/snmp-exporter/values.yaml
NEW infrastructure/monitoring/snmp-exporter-externalsecret.yaml
NEW infrastructure/monitoring/grafana-dashboards/grafana-dashboard-network-snmp-switch.yaml
EDIT infrastructure/monitoring/application.yaml                    (add ArgoCD app)
EDIT infrastructure/monitoring/kustomization.yaml                   (add ESO entry)
EDIT infrastructure/monitoring/grafana-dashboards/kustomization.yaml (add dashboard)
EDIT infrastructure/monitoring/kube-prometheus-stack/values.yaml   (scrape job + alerts)
```

## Pre-merge requirement

The switch's SNMP read community must be set to the value stored in the 1Password `Infrastructure` vault under item `192.168.1.2` field `community`. Until that's configured on the switch:
- ArgoCD will deploy the exporter and Prometheus will start scraping
- All scrapes will fail authentication
- `SnmpExporterDown` alert will fire after 3 minutes

Configure on switch via web UI (`MAINTENANCE → SNMP`) or SSH, then save running config to startup.

## Validation done

- `helm template` of the snmp-exporter chart renders cleanly with the Secret mount at the correct path
- `kubectl kustomize infrastructure/monitoring/` builds without errors
- Dashboard JSON parses (`python3 -m json.tool`), 13 panels, 3 templating variables
- All `additionalScrapeConfigs` and `additionalPrometheusRulesMap` entries parse via `yq`

## Test plan

- [ ] Merge after switch SNMP community is configured
- [ ] ArgoCD syncs `snmp-exporter` Application
- [ ] ESO produces `snmp-exporter-config` Secret in `monitoring` ns
- [ ] `kubectl -n monitoring logs deploy/snmp-exporter-prometheus-snmp-exporter` shows no SNMP errors
- [ ] Prometheus targets page shows `snmp-switch` job with `instance=lab-sw01` UP
- [ ] Grafana "Network / SNMP Switch" dashboard renders with port data
- [ ] Trigger a port-down event (unplug a non-critical cable) and verify `SwitchPortDown` fires within 5m