### PR TITLE
fix(monitoring): switch snmp-exporter to layered config files

### DIFF
--- a/infrastructure/monitoring/snmp-exporter-externalsecret.yaml
+++ b/infrastructure/monitoring/snmp-exporter-externalsecret.yaml
@@ -17,33 +17,11 @@ spec:
     template:
       type: Opaque
       data:
-        snmp.yml: |
+        auths.yml: |
           auths:
             switch_v2c:
               version: 2
               community: "{{ .community }}"
-          modules:
-            if_mib:
-              walk:
-                - sysUpTime
-                - interfaces
-                - ifXTable
-              lookups:
-                - source_indexes: [ifIndex]
-                  lookup: ifAlias
-                - source_indexes: [ifIndex]
-                  lookup: ifDescr
-                - source_indexes: [ifIndex]
-                  lookup: ifName
-              overrides:
-                ifAlias:
-                  ignore: true
-                ifDescr:
-                  ignore: true
-                ifName:
-                  type: DisplayString
-                ifType:
-                  type: EnumAsInfo
   data:
     - secretKey: community
       remoteRef:

--- a/infrastructure/monitoring/snmp-exporter/values.yaml
+++ b/infrastructure/monitoring/snmp-exporter/values.yaml
@@ -15,13 +15,18 @@ prometheus-snmp-exporter:
   serviceMonitor:
     enabled: false
 
+  # Load the container's bundled /etc/snmp_exporter/snmp.yml (full module
+  # definitions for if_mib and every other vendor MIB) AND our auths-only
+  # file from a Secret. snmp_exporter v0.30+ merges multiple --config.file
+  # invocations.
   extraArgs:
     - --config.file=/etc/snmp_exporter/snmp.yml
+    - --config.file=/etc/snmp_exporter/auths.yml
 
   extraSecretMounts:
     - name: snmp-exporter-config
-      mountPath: /etc/snmp_exporter/snmp.yml
-      subPath: snmp.yml
+      mountPath: /etc/snmp_exporter/auths.yml
+      subPath: auths.yml
       secretName: snmp-exporter-config
       readOnly: true
       defaultMode: 420


### PR DESCRIPTION
## Summary

PR #166 left snmp-exporter in CrashLoopBackOff. The hand-rolled \`snmp.yml\` used \`lookups\` and \`overrides\` at the module level, which were removed from the snmp_exporter v0.30.x schema. Pod logs:

\`\`\`
Error parsing config file ... yaml: unmarshal errors:
  line 11: field lookups not found in type config.plain
  line 18: field overrides not found in type config.plain
Possible version mismatch between generator and snmp_exporter.
\`\`\`

This is firing \`SnmpExporterDown\` and \`TargetDown\` in production.

## Approach

Rewriting a v0.30-compliant module config from scratch would mean ~1250 lines of YAML per module (auto-generated by the snmp_exporter generator). Pointless to vendor that.

Instead, leverage \`--config.file\` being repeatable in v0.30+:

1. Use the container's bundled \`/etc/snmp_exporter/snmp.yml\` (ships full upstream module definitions for if_mib and every other vendor MIB, contains no secrets)
2. Mount our ESO-rendered Secret as a tiny \`auths.yml\` (only the \`auths:\` section with the v2c community templated from 1P)
3. Pass both via \`extraArgs\`. snmp_exporter merges them at startup.

Same end-state as PR #166 intended; secret stays out of git.

## Diff

\`\`\`
infrastructure/monitoring/snmp-exporter-externalsecret.yaml   |  drop the modules block, keep auths only, key snmp.yml -> auths.yml
infrastructure/monitoring/snmp-exporter/values.yaml           |  pass --config.file twice, mount Secret at /etc/snmp_exporter/auths.yml
\`\`\`

No changes needed to the Prometheus scrape job (\`params.auth: [switch_v2c]\`) or alerts.

## Validation

- \`helm template\` shows both \`--config.file\` args in container args, Secret mounted at correct path with correct \`subPath\`
- snmpwalk against the switch from a LAN host with the same community string returns sysDescr and the full interface table (verified ~1h ago)

## Test plan

- [ ] Merge
- [ ] ArgoCD sync triggers Reloader to restart pod (pod annotation already set)
- [ ] \`kubectl -n monitoring logs deploy/snmp-exporter-prometheus-snmp-exporter\` shows clean startup, no parse errors
- [ ] \`SnmpExporterDown\` clears within 4m of pod going Ready
- [ ] Prometheus targets shows \`snmp-switch\` UP
- [ ] Grafana dashboard renders port data