### PR TITLE
feat(dashboard): add GoatCounter for docs.herro.me analytics

### DIFF
--- a/apps/dashboard/goatcounter/README.md
+++ b/apps/dashboard/goatcounter/README.md
@@ -1,0 +1,110 @@
+# GoatCounter
+
+Self-hosted, privacy-friendly analytics for static sites. Currently fronts
+[docs.herro.me](https://docs.herro.me); designed to host additional sites
+behind the same instance later.
+
+## Topology
+
+```
+visitor browser ──beacon──> NPM (192.168.1.150)
+                            └─https─> gc.herro.me
+                                       └─http─> 192.168.1.227:8080 (Service: goatcounter)
+                                                 └─ Pod: goatcounter (namespace: dashboard)
+                                                     └─ PVC: goatcounter-data (k8s-nfs, 1Gi)
+                                                         └─ SQLite at
+                                                            /home/user/.local/share/goatcounter/db/goatcounter.sqlite3
+```
+
+NPM terminates TLS. The pod runs plain HTTP inside the cluster.
+
+## Operational hazards
+
+- **Never `kubectl rollout restart`** this deployment. SQLite + NFS does not
+  tolerate overlapping writers. To restart safely:
+
+  ```bash
+  kubectl scale deploy goatcounter -n dashboard --replicas=0 \
+    && sleep 5 \
+    && kubectl scale deploy goatcounter -n dashboard --replicas=1
+  ```
+
+- Strategy is `Recreate` for the same reason. Same hazard pattern as the
+  *arr apps.
+- Data persistence relies on TrueNAS ZFS snapshots of the
+  `tank/k8s/dashboard-goatcounter-data-*` dataset. Verify snapshot
+  retention if you start treating the analytics as load-bearing.
+
+## First-run bootstrap
+
+After the manifests sync via ArgoCD and the pod is `Running`, do this once:
+
+1. **Pick an admin password and write it to 1Password.**
+
+   ```bash
+   # Generate
+   PW=$(openssl rand -base64 24)
+
+   # Store in 1Password Infrastructure vault as item:
+   #   Title: GoatCounter Admin
+   #   Username: naerois@gmail.com
+   #   Password: $PW
+   #   URL: https://gc.herro.me
+   op item create --vault Infrastructure --category login \
+       --title "GoatCounter Admin" \
+       --url "https://gc.herro.me" \
+       --generate-password='letters,digits,symbols,32'
+   ```
+
+2. **Create the docs.herro.me site row inside GoatCounter.**
+
+   ```bash
+   POD=$(kubectl -n dashboard get pod -l app.kubernetes.io/name=goatcounter -o name | head -n1)
+   kubectl -n dashboard exec -it "$POD" -- goatcounter db create site \
+       -vhost docs.herro.me \
+       -user.email naerois@gmail.com \
+       -user.password "$PW" \
+       -db sqlite+/home/user/.local/share/goatcounter/db/goatcounter.sqlite3
+   ```
+
+3. **Configure NPM proxy host** at `https://192.168.1.150:81/`:
+
+   - Domain Names: `gc.herro.me`
+   - Scheme: `http`
+   - Forward Hostname / IP: `192.168.1.227`
+   - Forward Port: `8080`
+   - Block Common Exploits: on
+   - Websockets Support: on (used by the live-update dashboard)
+   - SSL: Request a new Let's Encrypt certificate, Force SSL, HTTP/2,
+     HSTS enabled.
+
+   Make sure the DNS record for `gc.herro.me` resolves to the
+   WAN address that NPM is published behind (same as
+   `docs.herro.me` if you proxy that through NPM, or your usual
+   ingress IP).
+
+4. **Generate an API key** at `https://gc.herro.me/settings/api`,
+   scopes: `Read statistics`. Store as 1Password item
+   `GoatCounter API Key` in the Infrastructure vault. This key is
+   what the Homepage `customapi` widget will use (separate PR).
+
+5. **Wire the beacon into the MkDocs site** (separate commit in the
+   `quasarlab-docs` repo). Beacon snippet:
+
+   ```html
+   <script data-goatcounter="https://gc.herro.me/count"
+           async src="//gc.herro.me/count.js"></script>
+   ```
+
+## Upgrades
+
+```bash
+# Bump tag in values.yaml, then:
+make all
+git add -A
+git commit -m "feat(goatcounter): bump to vX.Y.Z"
+```
+
+Verify the upstream release notes for breaking schema changes before
+applying. GoatCounter runs auto-migrations on start (`-automigrate` flag),
+so most bumps are safe, but always check.

--- a/apps/dashboard/goatcounter/common.yaml
+++ b/apps/dashboard/goatcounter/common.yaml
@@ -1,0 +1,142 @@
+---
+# Source: app-template/templates/common.yaml
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: goatcounter-data
+  labels:
+    app.kubernetes.io/instance: goatcounter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: goatcounter
+    helm.sh/chart: app-template-3.5.1
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+  storageClassName: "k8s-nfs"
+---
+# Source: app-template/templates/common.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: goatcounter
+  labels:
+    app.kubernetes.io/instance: goatcounter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: goatcounter
+    app.kubernetes.io/service: goatcounter
+    helm.sh/chart: app-template-3.5.1
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.227
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/component: main
+    app.kubernetes.io/instance: goatcounter
+    app.kubernetes.io/name: goatcounter
+---
+# Source: app-template/templates/common.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goatcounter
+  labels:
+    app.kubernetes.io/component: main
+    app.kubernetes.io/instance: goatcounter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: goatcounter
+    helm.sh/chart: app-template-3.5.1
+spec:
+  revisionHistoryLimit: 3
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: main
+      app.kubernetes.io/name: goatcounter
+      app.kubernetes.io/instance: goatcounter
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/component: main
+        app.kubernetes.io/instance: goatcounter
+        app.kubernetes.io/name: goatcounter
+    spec: 
+      enableServiceLinks: false
+      serviceAccountName: default
+      automountServiceAccountToken: true
+      securityContext: 
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      dnsPolicy: ClusterFirst
+      containers: 
+        - args:
+          - serve
+          - -listen=:8080
+          - -tls=none
+          - -db=sqlite+/home/user/.local/share/goatcounter/db/goatcounter.sqlite3
+          - -automigrate
+          command:
+          - goatcounter
+          env:
+          - name: TZ
+            value: America/Los_Angeles
+          image: arp242/goatcounter:v2.5.4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            periodSeconds: 30
+            tcpSocket:
+              port: 8080
+          name: main
+          ports:
+          - containerPort: 8080
+            name: http
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 8080
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+          startupProbe:
+            failureThreshold: 60
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            tcpSocket:
+              port: 8080
+          volumeMounts:
+          - mountPath: /home/user/.local/share/goatcounter
+            name: data
+      volumes: 
+        - name: data
+          persistentVolumeClaim:
+            claimName: goatcounter-data

--- a/apps/dashboard/goatcounter/kustomization.yaml
+++ b/apps/dashboard/goatcounter/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - common.yaml

--- a/apps/dashboard/goatcounter/makefile
+++ b/apps/dashboard/goatcounter/makefile
@@ -1,0 +1,45 @@
+CHART_URI       ?= oci://ghcr.io/bjw-s/helm/app-template
+CHART_VERSION   ?= 3.5.1
+RELEASE_NAME    ?= goatcounter
+RELEASE_OUTPUT  := .helm-tmp-$(RELEASE_NAME)
+NAMESPACE       ?= dashboard
+VALUES_FILE     ?= values.yaml
+KUSTOMIZATION   ?= kustomization.yaml
+
+.PHONY: all render update-kustomize clean ensure-deps
+all: render update-kustomize
+
+ensure-deps:
+	@command -v helm >/dev/null 2>&1 || { echo "helm not installed"; exit 1; }
+	@command -v kubectl >/dev/null 2>&1 || { echo "kubectl not installed"; exit 1; }
+	@command -v yq >/dev/null 2>&1 || { echo "yq (v4+) is required"; exit 1; }
+	@echo "All dependencies installed"
+
+render:
+	@rm -rf $(RELEASE_OUTPUT); mkdir -p $(RELEASE_OUTPUT)
+	@helm template $(RELEASE_NAME) $(CHART_URI) --version $(CHART_VERSION) --namespace $(NAMESPACE) --include-crds --values $(VALUES_FILE) --output-dir $(RELEASE_OUTPUT)
+	@find $(RELEASE_OUTPUT) -type f -name '*.yaml' -exec cp {} ./ \;
+	@rm -rf $(RELEASE_OUTPUT) ./templates ./charts ./crds ./charts/crds ./charts/crds/templates
+	@echo "Rendered"
+
+update-kustomize:
+	@echo "resources:" > $(KUSTOMIZATION)
+	@EXCLUDE="kustomization.yaml values.yaml README.md Makefile makefile"; \
+	ORDERED_KINDS="Namespace StorageClass PersistentVolume PersistentVolumeClaim CustomResourceDefinition ServiceAccount Role RoleBinding ClusterRole ClusterRoleBinding ConfigMap Secret LimitRange ResourceQuota Deployment DaemonSet StatefulSet Job CronJob Service Ingress NetworkPolicy ValidatingWebhookConfiguration MutatingWebhookConfiguration"; \
+	for KIND in $$ORDERED_KINDS; do \
+		for file in *.yaml; do \
+			if [ -f "$$file" ] && ! echo "$$EXCLUDE" | grep -qw "$$file"; then \
+				FILE_KIND=$$(yq e '.kind // ""' "$$file" 2>/dev/null | grep -v '^$$' | head -n1); \
+				[ "$$FILE_KIND" = "$$KIND" ] && echo "  - $$file" >> $(KUSTOMIZATION); \
+			fi; \
+		done; \
+	done; \
+	for file in *.yaml; do \
+		if [ -f "$$file" ] && ! echo "$$EXCLUDE" | grep -qw "$$file"; then \
+			grep -q "  - $$file" $(KUSTOMIZATION) || echo "  - $$file" >> $(KUSTOMIZATION); \
+		fi; \
+	done
+	@echo "Kustomization updated"
+
+clean:
+	@find . -maxdepth 1 -name '*.yaml' -not -name '$(VALUES_FILE)' -not -name '$(KUSTOMIZATION)' -exec rm -f {} +

--- a/apps/dashboard/goatcounter/values.yaml
+++ b/apps/dashboard/goatcounter/values.yaml
@@ -1,0 +1,103 @@
+# GoatCounter analytics for docs.herro.me (and any other static site we want
+# to track later). Rendered via bjw-s/app-template 3.5.1 with `make all`.
+#
+# Operational notes:
+# - SQLite database lives on NFS (k8s-nfs StorageClass). NEVER use
+#   `kubectl rollout restart` on this deployment, the same way we never
+#   restart the *arr apps. Scale down then up:
+#       kubectl scale deploy goatcounter -n dashboard --replicas=0 \
+#         && sleep 5 \
+#         && kubectl scale deploy goatcounter -n dashboard --replicas=1
+# - First-run bootstrap (creating the docs.herro.me site row and admin user)
+#   is a manual `kubectl exec`. See ./README.md.
+# - NPM (192.168.1.150) reverse-proxies gc.herro.me to 192.168.1.227:8080
+#   and terminates TLS. GoatCounter itself runs plain HTTP inside the
+#   cluster, so `-tls=none` is set below.
+
+controllers:
+  main:
+    type: deployment
+    replicas: 1
+    strategy: Recreate
+    pod:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    containers:
+      main:
+        image:
+          repository: arp242/goatcounter
+          # Pin to a known-good tag. Bump deliberately, never use :latest.
+          tag: "v2.5.4"
+          pullPolicy: IfNotPresent
+        command: ["goatcounter"]
+        args:
+          - "serve"
+          - "-listen=:8080"
+          - "-tls=none"
+          - "-db=sqlite+/home/user/.local/share/goatcounter/db/goatcounter.sqlite3"
+          - "-automigrate"
+        env:
+          TZ: "America/Los_Angeles"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+        ports:
+          - name: http
+            containerPort: 8080
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket: { port: 8080 }
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 60
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket: { port: 8080 }
+              periodSeconds: 30
+              failureThreshold: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet: { path: "/status", port: 8080 }
+              periodSeconds: 10
+              failureThreshold: 3
+
+service:
+  main:
+    controller: main
+    type: LoadBalancer
+    loadBalancerIP: 192.168.1.227
+    ports:
+      http:
+        port: 8080
+        targetPort: http
+
+persistence:
+  data:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: k8s-nfs
+    globalMounts:
+      - path: /home/user/.local/share/goatcounter

--- a/apps/dashboard/kustomization.yaml
+++ b/apps/dashboard/kustomization.yaml
@@ -2,3 +2,4 @@ namespace: dashboard
 resources:
   - dashboard-namespace.yaml
   - homepage/
+  - goatcounter/


### PR DESCRIPTION
## What

Adds a self-hosted GoatCounter instance under `apps/dashboard/goatcounter/`
to back daily-visit analytics for `docs.herro.me`. Designed so it can host
additional sites later (one GC instance, multiple `-vhost`s).

## Why

`docs.herro.me` is served by GitHub Pages, which exposes no traffic API on
the GitHub side. To track visits without GA / Cloudflare lock-in, we need
our own beacon endpoint. GoatCounter is the lightest privacy-friendly
option that fits the existing k8s-argocd / NPM topology and exposes a
clean JSON API for the Homepage widget that will follow.

## Architecture

- bjw-s/app-template 3.5.1, image pinned to `arp242/goatcounter:v2.5.4`
- LoadBalancer at `192.168.1.227`, plain HTTP inside cluster
- NPM (192.168.1.150) terminates TLS at `gc.herro.me`
- SQLite database on `k8s-nfs` PVC (1 GiB), `Recreate` strategy
- Same NFS + SQLite hazard pattern as the *arr apps. README documents the
  safe scale-down then scale-up restart pattern. Do NOT
  `kubectl rollout restart`.

## Bootstrap (manual, after merge)

1. ArgoCD syncs the pod.
2. `kubectl -n dashboard exec <pod> -- goatcounter db create site -vhost docs.herro.me ...`
3. Save admin password to 1Password (`GoatCounter Admin`).
4. Wire NPM proxy host `gc.herro.me` to `192.168.1.227:8080` with LE cert.
5. Generate API key in the GC UI, save to 1Password (`GoatCounter API Key`).

Full steps in `apps/dashboard/goatcounter/README.md`.

## Follow-up PRs

- `quasarlab-docs`: add the GoatCounter beacon snippet to MkDocs.
- `k8s-argocd`: ExternalSecret for the GC API key + Homepage `customapi`
  widget for the docs visits and the `quasarlab-docs` GitHub traffic
  views (PAT-backed).

## Validation

- `kubectl kustomize apps/dashboard/ | kubectl apply --dry-run=client -f -` passes.
- No em dashes, no real secrets in the diff.
- Single-replica `Recreate` deployment, runs as uid 1000, drops all caps,
  read-only-root is off (GoatCounter writes to its data dir, which is the
  mounted PVC).

## Test plan

- [ ] ArgoCD shows the new Application sync as healthy.
- [ ] `kubectl -n dashboard get pod -l app.kubernetes.io/name=goatcounter` Running.
- [ ] Manual bootstrap completes, GC UI reachable at https://gc.herro.me.
- [ ] Test beacon hit from `curl` returns 200.
- [ ] No new alerts firing in Alertmanager (no PrometheusRules added here).