### PR TITLE
fix(goatcounter): correct image tag to 2.7.0

### DIFF
--- a/apps/dashboard/goatcounter/common.yaml
+++ b/apps/dashboard/goatcounter/common.yaml
@@ -97,7 +97,7 @@ spec:
           env:
           - name: TZ
             value: America/Los_Angeles
-          image: arp242/goatcounter:v2.5.4
+          image: arp242/goatcounter:2.7.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5

--- a/apps/dashboard/goatcounter/values.yaml
+++ b/apps/dashboard/goatcounter/values.yaml
@@ -33,7 +33,8 @@ controllers:
         image:
           repository: arp242/goatcounter
           # Pin to a known-good tag. Bump deliberately, never use :latest.
-          tag: "v2.5.4"
+          # Upstream tags are unprefixed (no leading "v"); see Docker Hub.
+          tag: "2.7.0"
           pullPolicy: IfNotPresent
         command: ["goatcounter"]
         args:


### PR DESCRIPTION
Upstream arp242/goatcounter tags on Docker Hub don't carry a `v` prefix and `v2.5.4` was never published. Pod was stuck in ImagePullBackOff against the original tag from #168.

Bumping to 2.7.0 (current stable, published 2025-12-15).