### PR TITLE
feat(automation): add donchian-signal CronJob app

### DIFF
--- a/apps/automation/donchian-signal/Makefile
+++ b/apps/automation/donchian-signal/Makefile
@@ -1,0 +1,22 @@
+CHART_DIR := $(HOME)/code/palantir-nq/deploy/helm/donchian-signal
+NAMESPACE := automation
+
+.PHONY: all render update-kustomize clean
+
+all: render update-kustomize
+
+render:
+	helm template donchian-signal $(CHART_DIR) \
+		--namespace $(NAMESPACE) \
+		--set namespace=$(NAMESPACE) \
+		> /tmp/donchian-signal-rendered.yaml
+	python3 -c "import yaml; docs = [d for d in yaml.safe_load_all(open('/tmp/donchian-signal-rendered.yaml')) if d]; \
+import os; \
+[open({'ConfigMap':'configmap-grafana-dashboard.yaml','CronJob':'cronjob.yaml','ExternalSecret':'externalsecret.yaml'}[d['kind']], 'w').write(yaml.dump(d, sort_keys=False, default_flow_style=False)) for d in docs]"
+	rm /tmp/donchian-signal-rendered.yaml
+
+update-kustomize:
+	@echo "kustomization.yaml is hand-curated to preserve resource ordering"
+
+clean:
+	rm -f cronjob.yaml externalsecret.yaml configmap-grafana-dashboard.yaml

--- a/apps/automation/donchian-signal/configmap-grafana-dashboard.yaml
+++ b/apps/automation/donchian-signal/configmap-grafana-dashboard.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: donchian-signal-donchian-signal-grafana-dashboard
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: donchian-signal
+    app.kubernetes.io/instance: donchian-signal
+    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: signal-generator
+    grafana_dashboard: '1'
+data:
+  donchian_forward.json: "\n{\n  \"annotations\": {\"list\": []},\n  \"description\"\
+    : \"Donchian-10/5 swing forward-test: signals fired, trades logged, cumulative\
+    \ P&L vs backtest baseline, slippage distribution.\",\n  \"editable\": true,\n\
+    \  \"graphTooltip\": 0,\n  \"panels\": [\n    {\n      \"id\": 1,\n      \"type\"\
+    : \"stat\",\n      \"title\": \"Signals fired (last 90d)\",\n      \"gridPos\"\
+    : {\"x\": 0, \"y\": 0, \"w\": 6, \"h\": 4},\n      \"targets\": [\n        {\n\
+    \          \"rawSql\": \"SELECT COUNT(*) FROM donchian_signals WHERE signal_date\
+    \ > NOW() - INTERVAL '90 days' AND skip_reason IS NULL\",\n          \"format\"\
+    : \"table\",\n          \"refId\": \"A\"\n        }\n      ],\n      \"datasource\"\
+    : {\"type\": \"postgres\", \"uid\": \"postgres-palantir-nq\"}\n    },\n    {\n\
+    \      \"id\": 2,\n      \"type\": \"stat\",\n      \"title\": \"Trades logged\
+    \ (last 90d)\",\n      \"gridPos\": {\"x\": 6, \"y\": 0, \"w\": 6, \"h\": 4},\n\
+    \      \"targets\": [\n        {\n          \"rawSql\": \"SELECT COUNT(*) FROM\
+    \ donchian_trades dt JOIN donchian_signals ds ON dt.signal_id = ds.signal_id WHERE\
+    \ ds.signal_date > NOW() - INTERVAL '90 days'\",\n          \"format\": \"table\"\
+    ,\n          \"refId\": \"A\"\n        }\n      ],\n      \"datasource\": {\"\
+    type\": \"postgres\", \"uid\": \"postgres-palantir-nq\"}\n    },\n    {\n    \
+    \  \"id\": 3,\n      \"type\": \"stat\",\n      \"title\": \"Open positions\"\
+    ,\n      \"gridPos\": {\"x\": 12, \"y\": 0, \"w\": 6, \"h\": 4},\n      \"targets\"\
+    : [\n        {\n          \"rawSql\": \"SELECT COUNT(*) FROM donchian_trades WHERE\
+    \ exit_ts IS NULL\",\n          \"format\": \"table\",\n          \"refId\": \"\
+    A\"\n        }\n      ],\n      \"datasource\": {\"type\": \"postgres\", \"uid\"\
+    : \"postgres-palantir-nq\"}\n    },\n    {\n      \"id\": 4,\n      \"type\":\
+    \ \"stat\",\n      \"title\": \"Cumulative forward $ (closed)\",\n      \"gridPos\"\
+    : {\"x\": 18, \"y\": 0, \"w\": 6, \"h\": 4},\n      \"targets\": [\n        {\n\
+    \          \"rawSql\": \"SELECT COALESCE(SUM(pnl_dollars_actual), 0) FROM donchian_trades\
+    \ WHERE exit_ts IS NOT NULL\",\n          \"format\": \"table\",\n          \"\
+    refId\": \"A\"\n        }\n      ],\n      \"datasource\": {\"type\": \"postgres\"\
+    , \"uid\": \"postgres-palantir-nq\"},\n      \"fieldConfig\": {\"defaults\": {\"\
+    unit\": \"currencyUSD\"}}\n    },\n    {\n      \"id\": 5,\n      \"type\": \"\
+    timeseries\",\n      \"title\": \"Cumulative forward P&L vs trade #\",\n     \
+    \ \"gridPos\": {\"x\": 0, \"y\": 4, \"w\": 24, \"h\": 8},\n      \"targets\":\
+    \ [\n        {\n          \"rawSql\": \"SELECT exit_ts AS time, SUM(pnl_dollars_actual)\
+    \ OVER (ORDER BY exit_ts) AS cumulative_usd FROM donchian_trades WHERE exit_ts\
+    \ IS NOT NULL ORDER BY exit_ts\",\n          \"format\": \"time_series\",\n  \
+    \        \"refId\": \"A\"\n        }\n      ],\n      \"datasource\": {\"type\"\
+    : \"postgres\", \"uid\": \"postgres-palantir-nq\"},\n      \"fieldConfig\": {\"\
+    defaults\": {\"unit\": \"currencyUSD\"}}\n    },\n    {\n      \"id\": 6,\n  \
+    \    \"type\": \"table\",\n      \"title\": \"Recent signals (last 30d)\",\n \
+    \     \"gridPos\": {\"x\": 0, \"y\": 12, \"w\": 12, \"h\": 10},\n      \"targets\"\
+    : [\n        {\n          \"rawSql\": \"SELECT signal_date, side, breakout_level,\
+    \ todays_close, initial_stop_px, skip_reason, status FROM donchian_signals WHERE\
+    \ signal_date > NOW() - INTERVAL '30 days' ORDER BY signal_date DESC\",\n    \
+    \      \"format\": \"table\",\n          \"refId\": \"A\"\n        }\n      ],\n\
+    \      \"datasource\": {\"type\": \"postgres\", \"uid\": \"postgres-palantir-nq\"\
+    }\n    },\n    {\n      \"id\": 7,\n      \"type\": \"table\",\n      \"title\"\
+    : \"Slippage: actual vs expected entry\",\n      \"gridPos\": {\"x\": 12, \"y\"\
+    : 12, \"w\": 12, \"h\": 10},\n      \"targets\": [\n        {\n          \"rawSql\"\
+    : \"SELECT ds.signal_date, ds.side, ds.entry_px_expected, dt.entry_px_actual,\
+    \ dt.slippage_vs_expected_pts FROM donchian_trades dt JOIN donchian_signals ds\
+    \ ON dt.signal_id = ds.signal_id ORDER BY ds.signal_date DESC LIMIT 30\",\n  \
+    \        \"format\": \"table\",\n          \"refId\": \"A\"\n        }\n     \
+    \ ],\n      \"datasource\": {\"type\": \"postgres\", \"uid\": \"postgres-palantir-nq\"\
+    }\n    }\n  ],\n  \"schemaVersion\": 38,\n  \"tags\": [\"palantir-nq\", \"donchian\"\
+    , \"forward-test\"],\n  \"timezone\": \"America/New_York\",\n  \"title\": \"Donchian\
+    \ Swing Forward-Test\",\n  \"uid\": \"donchian-forward\",\n  \"version\": 1\n}"

--- a/apps/automation/donchian-signal/cronjob.yaml
+++ b/apps/automation/donchian-signal/cronjob.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: donchian-signal-donchian-signal
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: donchian-signal
+    app.kubernetes.io/instance: donchian-signal
+    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: signal-generator
+spec:
+  schedule: 5 16 * * MON-FRI
+  timeZone: America/New_York
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: donchian-signal
+            app.kubernetes.io/instance: donchian-signal
+            app.kubernetes.io/version: 0.1.0
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/component: signal-generator
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: signal
+            image: ghcr.io/mithr4ndir/palantir-nq:0.1.0
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+            args:
+            - python
+            - -m
+            - nq_ibb.forward.cronjob_entrypoint
+            envFrom:
+            - secretRef:
+                name: donchian-signal-donchian-signal-secrets
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 100m
+                memory: 256Mi
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}

--- a/apps/automation/donchian-signal/externalsecret.yaml
+++ b/apps/automation/donchian-signal/externalsecret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: donchian-signal-donchian-signal-secrets
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: donchian-signal
+    app.kubernetes.io/instance: donchian-signal
+    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: signal-generator
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infrastructure
+  target:
+    name: donchian-signal-donchian-signal-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: DONCHIAN_DISCORD_WEBHOOK
+    remoteRef:
+      key: rmmf24ed3vvjffafar6wtah4ky
+      property: webhook_url
+  - secretKey: NQ_IBB_DB_URL
+    remoteRef:
+      key: 6quj7qxa3kzp2nwabtsh5drpd4
+      property: dsn

--- a/apps/automation/donchian-signal/kustomization.yaml
+++ b/apps/automation/donchian-signal/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - cronjob.yaml
+  - configmap-grafana-dashboard.yaml

--- a/apps/automation/kustomization.yaml
+++ b/apps/automation/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   # api-key-local-hook, api-key-remote-agent, postgres dsn/migrate_dsn)
   # are validated in the Infrastructure vault.
   # - claude-bridge/
+  - donchian-signal/


### PR DESCRIPTION
## Summary

- Daily Donchian-10/5 swing signal generator CronJob (16:05 ET Mon-Fri, America/New_York)
- Pulls live NQ daily close via yfinance, evaluates breakout rule, writes to `donchian_signals` table
- Posts themed Discord embed to `#trading-signals` channel when a break fires
- 7-panel Grafana dashboard rendered alongside (signals fired, trades logged, cumulative forward P&L, slippage distribution)

## What's in this PR

Three flat manifests rendered from the source chart at `$HOME/code/palantir-nq/deploy/helm/donchian-signal` v0.1.0:

- `externalsecret.yaml`: ESO pulls `DONCHIAN_DISCORD_WEBHOOK` from 1P item `rmmf24ed3vvjffafar6wtah4ky` (Trading Signals Discord Webhook) and `NQ_IBB_DB_URL` from item `6quj7qxa3kzp2nwabtsh5drpd4` (palantir-nq/postgres-dsn, app role)
- `cronjob.yaml`: schedule `5 16 * * MON-FRI`, timezone `America/New_York`, security context non-root, readOnlyRootFilesystem, capabilities dropped
- `configmap-grafana-dashboard.yaml`: forward-test dashboard picked up by the kube-prometheus-stack grafana sidecar

Plus `Makefile` for re-rendering against the source chart (`make render`).

## Infrastructure already in place

- Postgres DB `nq_ibb` provisioned on 192.168.1.123:5432 with two roles (`nq_ibb_app` for read/write, `nq_ibb_migrate` for DDL)
- Alembic migrations `0001_initial_schema` + `0002_donchian_forward` applied (7 tables)
- 1P items created in Infrastructure vault for both the Discord webhook and the postgres DSNs
- End-to-end smoke test against the real webhook + DB verified Discord HTTP 204 and DB insert/delete round-trip

## Test plan

- [ ] ArgoCD picks up the new app under `apps/automation/` after merge
- [ ] CronJob appears in the `automation` namespace via `kubectl get cronjob -n automation donchian-signal-donchian-signal`
- [ ] ExternalSecret syncs and mounts both secrets without error
- [ ] First weekday cron run (16:05 ET) either emits a signal alert to Discord or logs "no Donchian break" and exits 0
- [ ] Grafana picks up the new dashboard `Donchian Swing Forward-Test`