### PR TITLE
fix(donchian-signal): bump ExternalSecret to external-secrets.io/v1

### DIFF
--- a/apps/automation/donchian-signal/externalsecret.yaml
+++ b/apps/automation/donchian-signal/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: donchian-signal-donchian-signal-secrets


### PR DESCRIPTION
## Summary

- PR #171 sync failed because the rendered ExternalSecret pinned `external-secrets.io/v1beta1`, which this cluster's ESO no longer serves
- Bumps the apiVersion to `v1` (the version actually installed)
- Same fix landed in the source helm chart at \`palantir-nq/deploy/helm/donchian-signal/templates/externalsecret.yaml\`

## Test plan

- [ ] ArgoCD re-syncs cleanly
- [ ] `kubectl get externalsecret -n automation` shows the resource
- [ ] Secret `donchian-signal-donchian-signal-secrets` materializes with both keys
- [ ] CronJob lands and is schedulable