### PR TITLE
fix(donchian-signal): use slash-form key for ESO 1P remoteRef

### DIFF
--- a/apps/automation/donchian-signal/externalsecret.yaml
+++ b/apps/automation/donchian-signal/externalsecret.yaml
@@ -20,9 +20,7 @@ spec:
   data:
   - secretKey: DONCHIAN_DISCORD_WEBHOOK
     remoteRef:
-      key: rmmf24ed3vvjffafar6wtah4ky
-      property: webhook_url
+      key: rmmf24ed3vvjffafar6wtah4ky/webhook_url
   - secretKey: NQ_IBB_DB_URL
     remoteRef:
-      key: 6quj7qxa3kzp2nwabtsh5drpd4
-      property: dsn
+      key: 6quj7qxa3kzp2nwabtsh5drpd4/dsn


### PR DESCRIPTION
## Summary

After PR #172 cleared the apiVersion error, ESO still rejected the ExternalSecret with:

\`\`\`
error resolving secret reference: the secret reference could not be parsed:
secret reference has invalid format - must be
"op://<vault>/<item>/[section/]field[?attribute=<attribute-value>]"
\`\`\`

This cluster's 1Password Connect provider uses inline slash-form keys (\`<item-id>/<field>\`), not the separate \`key\` + \`property\` split. Verified by inspecting other working ExternalSecrets in the cluster (\`homepage-api-keys\`, \`grafana-secrets\`, \`discord-webhook-url\`, \`healthchecks-watchdog\` all use the slash form).

Same fix mirrored in the source helm chart at \`palantir-nq/deploy/helm/donchian-signal/templates/externalsecret.yaml\`.

## Test plan

- [ ] ExternalSecret status reaches \`SecretSynced=True\`
- [ ] Secret \`donchian-signal-donchian-signal-secrets\` materializes with both keys
- [ ] CronJob pod can mount and start