### PR TITLE
fix(donchian-signal): drop redundant python arg from CronJob

### DIFF
--- a/apps/automation/donchian-signal/cronjob.yaml
+++ b/apps/automation/donchian-signal/cronjob.yaml
@@ -47,7 +47,6 @@ spec:
                 - ALL
               readOnlyRootFilesystem: true
             args:
-            - python
             - -m
             - nq_ibb.forward.cronjob_entrypoint
             envFrom:


### PR DESCRIPTION
## Summary

After PRs #171, #172, and #173 cleared the kustomize / apiVersion / 1P-ref issues, the pod finally pulled the image but crash-looped with:

\`\`\`
python: can't open file '/app/python': [Errno 2] No such file or directory
\`\`\`

Caused by ENTRYPOINT=\`["python"]\` in the Dockerfile + args=\`["python","-m","..."]\` in the CronJob: Kubernetes appends args to ENTRYPOINT, so the actual command became \`python python -m nq_ibb.forward.cronjob_entrypoint\`, which made python interpret "python" as a script path.

Drop the leading "python" so args is just \`["-m","nq_ibb.forward.cronjob_entrypoint"]\`. Same fix landed in the source chart at palantir-nq.

## Test plan

- [ ] Pod reaches Succeeded state on next manual cron run
- [ ] Logs show "Donchian signal generator firing for YYYY-MM-DD"