### PR TITLE
feat(donchian-signal): bump to 0.1.1, no-signal heartbeat

### DIFF
--- a/apps/automation/donchian-signal/configmap-grafana-dashboard.yaml
+++ b/apps/automation/donchian-signal/configmap-grafana-dashboard.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: donchian-signal
     app.kubernetes.io/instance: donchian-signal
-    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/version: 0.1.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: signal-generator
     grafana_dashboard: '1'

--- a/apps/automation/donchian-signal/cronjob.yaml
+++ b/apps/automation/donchian-signal/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: donchian-signal
     app.kubernetes.io/instance: donchian-signal
-    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/version: 0.1.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: signal-generator
 spec:
@@ -24,7 +24,7 @@ spec:
           labels:
             app.kubernetes.io/name: donchian-signal
             app.kubernetes.io/instance: donchian-signal
-            app.kubernetes.io/version: 0.1.0
+            app.kubernetes.io/version: 0.1.1
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/component: signal-generator
         spec:
@@ -38,7 +38,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: signal
-            image: ghcr.io/mithr4ndir/palantir-nq:0.1.0
+            image: ghcr.io/mithr4ndir/palantir-nq:0.1.1
             imagePullPolicy: IfNotPresent
             securityContext:
               allowPrivilegeEscalation: false

--- a/apps/automation/donchian-signal/cronjob.yaml
+++ b/apps/automation/donchian-signal/cronjob.yaml
@@ -47,7 +47,6 @@ spec:
                 - ALL
               readOnlyRootFilesystem: true
             args:
-            - python
             - -m
             - nq_ibb.forward.cronjob_entrypoint
             envFrom:

--- a/apps/automation/donchian-signal/externalsecret.yaml
+++ b/apps/automation/donchian-signal/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: donchian-signal
     app.kubernetes.io/instance: donchian-signal
-    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/version: 0.1.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: signal-generator
 spec:


### PR DESCRIPTION
## Summary

- palantir-nq image bumped to 0.1.1
- Adds a compact no-signal Discord embed posted by the cron after every successful evaluation that didn't produce a Donchian break
- Backtest fires ~1 signal per 3 weeks on average; without a heartbeat, silence is indistinguishable from a dead cron

Heartbeat embed format:

> :sleeping: **Donchian heartbeat: no break on YYYY-MM-DD**
> Cron ran successfully, no signal generated. close=XXXXX.XX
> Next check: tomorrow 16:05 ET.

Wrapped in try/except so a flaky webhook can't break the cron itself.

## Test plan

- [ ] Pod runs to completion on next manual fire
- [ ] Discord shows the muted heartbeat embed (gray-blue, distinct from signal alerts)
- [ ] DB unchanged on no-signal days