### PR TITLE
feat(automation): add Dream Team Indicators (pre-market NQ levels)

### DIFF
--- a/apps/automation/dream-team/configmap-grafana-dashboard.yaml
+++ b/apps/automation/dream-team/configmap-grafana-dashboard.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dream-team-dream-team-grafana-dashboard
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/instance: dream-team
+    app.kubernetes.io/version: 0.1.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: dream-team
+    grafana_dashboard: '1'
+data:
+  dream_team_levels.json: "\n{\n  \"annotations\": {\"list\": []},\n  \"description\"\
+    : \"Dream Team Indicators: latest NQ pre-market reference levels (PDH/PDL/Settle/PVAH/POC/PVAL/LWH/LWL).\"\
+    ,\n  \"editable\": true,\n  \"graphTooltip\": 0,\n  \"panels\": [\n    {\n   \
+    \   \"id\": 1,\n      \"type\": \"table\",\n      \"title\": \"Latest Dream Team\
+    \ Levels (NQ)\",\n      \"gridPos\": {\"x\": 0, \"y\": 0, \"w\": 24, \"h\": 12},\n\
+    \      \"datasource\": {\"type\": \"postgres\", \"uid\": \"postgres-palantir-nq\"\
+    },\n      \"targets\": [\n        {\n          \"rawSql\": \"SELECT 'LWH' AS level,\
+    \ lwh AS price FROM dream_team_levels ORDER BY target_date DESC LIMIT 1 UNION\
+    \ ALL SELECT 'PDH', pdh FROM dream_team_levels ORDER BY target_date DESC LIMIT\
+    \ 1 UNION ALL SELECT 'PVAH', pvah FROM dream_team_levels ORDER BY target_date\
+    \ DESC LIMIT 1 UNION ALL SELECT 'POC', poc FROM dream_team_levels ORDER BY target_date\
+    \ DESC LIMIT 1 UNION ALL SELECT 'Settle', settle FROM dream_team_levels ORDER\
+    \ BY target_date DESC LIMIT 1 UNION ALL SELECT 'PVAL', pval FROM dream_team_levels\
+    \ ORDER BY target_date DESC LIMIT 1 UNION ALL SELECT 'PDL', pdl FROM dream_team_levels\
+    \ ORDER BY target_date DESC LIMIT 1 UNION ALL SELECT 'LWL', lwl FROM dream_team_levels\
+    \ ORDER BY target_date DESC LIMIT 1\",\n          \"format\": \"table\",\n   \
+    \       \"refId\": \"A\"\n        }\n      ],\n      \"fieldConfig\": {\"defaults\"\
+    : {\"custom\": {\"align\": \"auto\"}}, \"overrides\": []},\n      \"transformations\"\
+    : [{\"id\": \"sortBy\", \"options\": {\"fields\": {}, \"sort\": [{\"field\": \"\
+    price\", \"desc\": true}]}}]\n    },\n    {\n      \"id\": 2,\n      \"type\"\
+    : \"stat\",\n      \"title\": \"Reference session\",\n      \"gridPos\": {\"x\"\
+    : 0, \"y\": 12, \"w\": 8, \"h\": 4},\n      \"datasource\": {\"type\": \"postgres\"\
+    , \"uid\": \"postgres-palantir-nq\"},\n      \"targets\": [\n        {\n     \
+    \     \"rawSql\": \"SELECT reference_date FROM dream_team_levels ORDER BY target_date\
+    \ DESC LIMIT 1\",\n          \"format\": \"table\",\n          \"refId\": \"A\"\
+    \n        }\n      ]\n    }\n  ],\n  \"schemaVersion\": 38,\n  \"tags\": [\"palantir-nq\"\
+    , \"dream-team\", \"levels\"],\n  \"timezone\": \"America/New_York\",\n  \"title\"\
+    : \"Dream Team Indicators\",\n  \"uid\": \"dream-team-levels\",\n  \"version\"\
+    : 1\n}"

--- a/apps/automation/dream-team/cronjob.yaml
+++ b/apps/automation/dream-team/cronjob.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dream-team-dream-team
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/instance: dream-team
+    app.kubernetes.io/version: 0.1.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: dream-team
+spec:
+  schedule: 0 8 * * MON-FRI
+  timeZone: America/New_York
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: dream-team
+            app.kubernetes.io/instance: dream-team
+            app.kubernetes.io/version: 0.1.2
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/component: dream-team
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: levels
+            image: ghcr.io/mithr4ndir/palantir-nq:0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+            args:
+            - -m
+            - nq_ibb.forward.dream_team_cron
+            envFrom:
+            - secretRef:
+                name: dream-team-dream-team-secrets
+            env:
+            - name: HOME
+              value: /tmp
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 100m
+                memory: 256Mi
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}

--- a/apps/automation/dream-team/deployment.yaml
+++ b/apps/automation/dream-team/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dream-team-dream-team-web
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/instance: dream-team
+    app.kubernetes.io/version: 0.1.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: dream-team
+    app.kubernetes.io/part: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dream-team
+      app.kubernetes.io/part: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dream-team
+        app.kubernetes.io/instance: dream-team
+        app.kubernetes.io/version: 0.1.2
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: dream-team
+        app.kubernetes.io/part: web
+    spec:
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: web
+        image: ghcr.io/mithr4ndir/palantir-nq:0.1.2
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        command:
+        - uvicorn
+        - nq_ibb.forward.dream_team_web:app
+        - --host
+        - 0.0.0.0
+        - --port
+        - '8080'
+        ports:
+        - name: http
+          containerPort: 8080
+        envFrom:
+        - secretRef:
+            name: dream-team-dream-team-secrets
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi

--- a/apps/automation/dream-team/externalsecret.yaml
+++ b/apps/automation/dream-team/externalsecret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dream-team-dream-team-secrets
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/instance: dream-team
+    app.kubernetes.io/version: 0.1.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: dream-team
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infrastructure
+  target:
+    name: dream-team-dream-team-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: NQ_IBB_DB_URL
+    remoteRef:
+      key: 6quj7qxa3kzp2nwabtsh5drpd4/dsn
+  - secretKey: DONCHIAN_DISCORD_WEBHOOK
+    remoteRef:
+      key: rmmf24ed3vvjffafar6wtah4ky/webhook_url
+  - secretKey: DATABENTO_API_KEY
+    remoteRef:
+      key: fggfsbldveuhioaflhh6pzfnpi/api_key

--- a/apps/automation/dream-team/kustomization.yaml
+++ b/apps/automation/dream-team/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - cronjob.yaml
+  - deployment.yaml
+  - service.yaml
+  - configmap-grafana-dashboard.yaml

--- a/apps/automation/dream-team/service.yaml
+++ b/apps/automation/dream-team/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dream-team-dream-team-web
+  namespace: automation
+  labels:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/instance: dream-team
+    app.kubernetes.io/version: 0.1.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: dream-team
+    app.kubernetes.io/part: web
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 192.168.1.235
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.235
+  selector:
+    app.kubernetes.io/name: dream-team
+    app.kubernetes.io/part: web
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP

--- a/apps/automation/kustomization.yaml
+++ b/apps/automation/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   # are validated in the Infrastructure vault.
   # - claude-bridge/
   - donchian-signal/
+  - dream-team/


### PR DESCRIPTION
## Summary

"Dream Team Indicators" — daily NQ pre-market reference levels the user trades off of, across **three surfaces**:

1. **Discord** — 08:00 ET weekday price-ladder embed to #trading-signals
2. **LAN web app** — FastAPI dark-theme ladder at http://192.168.1.235 (`/api/levels` JSON + `/healthz`)
3. **Grafana** — levels table dashboard in the monitoring stack

## Levels (calibrated to Topstep)

| Source | Levels | Match |
|---|---|---|
| yfinance daily | PDH, PDL, Settle, LWH, LWL | exact |
| Databento (30-min TPO, 25-tick, RTH, 70%) | PVAH, POC, PVAL | within 8 pts |

Weekly kickoff (WKOH/WKOL) deferred pending the user's Topstep session definition (their 28100 low is ~700pts outside any pullable session).

## Components

- `cronjob.yaml` — 08:00 ET weekdays (`0 8 * * MON-FRI`, America/New_York), runs `dream_team_cron`
- `deployment.yaml` + `service.yaml` — FastAPI web app, LoadBalancer 192.168.1.235 (LAN-only)
- `externalsecret.yaml` — DB DSN + Discord webhook + Databento key from 1P (slash-form refs)
- `configmap-grafana-dashboard.yaml` — Grafana levels table

Image `ghcr.io/mithr4ndir/palantir-nq:0.1.2` (adds fastapi + uvicorn), public, verified pullable.

## Verified end-to-end (local, against real services)

- All 8 levels within 8pts of Topstep (POC 1.5pt drift)
- DB upsert into `dream_team_levels` ✓
- Discord embed posted (HTTP 204) ✓
- Web app renders ladder + serves JSON ✓
- helm lint + kustomize build clean ✓

## Test plan post-merge

- [ ] ArgoCD syncs all 5 resources to `automation`
- [ ] ExternalSecret reaches SecretSynced=True (DB + Discord + Databento keys)
- [ ] Web app reachable at http://192.168.1.235
- [ ] CronJob fires next weekday 08:00 ET with a fresh levels embed
- [ ] Grafana shows the Dream Team Indicators dashboard