### PR TITLE
fix(dream-team): drop deprecated spec.loadBalancerIP

### DIFF
--- a/apps/automation/dream-team/service.yaml
+++ b/apps/automation/dream-team/service.yaml
@@ -14,7 +14,6 @@ metadata:
     metallb.universe.tf/loadBalancerIPs: 192.168.1.235
 spec:
   type: LoadBalancer
-  loadBalancerIP: 192.168.1.235
   selector:
     app.kubernetes.io/name: dream-team
     app.kubernetes.io/part: web


### PR DESCRIPTION
MetalLB rejected the web Service with AllocationFailed: 'can not have both metallb.io/loadBalancerIPs and svc.Spec.LoadBalancerIP'. Removes the deprecated spec.loadBalancerIP, keeps the annotation to pin 192.168.1.235. Mirrored in palantir-nq chart source.