### PR TITLE
chore: add eso/media specs, loki Chart.lock, gitignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # Helm
 **/charts/
 *.tgz
+
+# Local MCP config
+.mcp.json

--- a/.spec-workflow/specs/eso-rate-limit-hardening/requirements.md
+++ b/.spec-workflow/specs/eso-rate-limit-hardening/requirements.md
@@ -1,0 +1,102 @@
+# Requirements Document
+
+## Introduction
+
+Resume the paused ESO-side rate-limit mitigation work from the 2026-04-18 incident. ESO was scaled to 0 during the drain and then quietly scaled back to 1/1 once the cap recovered. The structural fix, a circuit breaker that stops ESO from retrying against an exhausted 1Password cap, was never shipped. This spec closes that gap.
+
+The goal is a deterministic posture: if the 1P account daily cap is exhausted, ESO MUST stop calling `op` until the window resets. Today ESO keeps reconciling every `refreshInterval` + every ClusterSecretStore validation tick regardless, and each failing reconcile still counts against the cap. The mitigation in the runbook ("scale ESO to 0") is manual and easy to forget, and it loses all secret sync until someone remembers to scale back.
+
+Scope is bounded to the External Secrets Operator deployment, the `onepassword-infrastructure` ClusterSecretStore, and the fleet of ExternalSecret resources that reference it. Alerting and quota observability already exist (spec `1password-quota-monitoring`, PR #109 + k8s-argocd monitoring PR), so this spec consumes those metrics rather than adding new ones.
+
+This is a prerequisite for the `media-secrets-declarative` spec, which will add ~7 new ExternalSecret resources across the media namespace and would amplify the drain risk if shipped first.
+
+## Alignment with Product Vision
+
+Homelab prime directive: everything must be managed in code (IaC), no manual configuration. The current "scale ESO to 0 by hand during an incident" response violates that directive. This spec makes the rate-limit protection declarative and enforced by Kubernetes itself, consistent with the existing ansible-side kill switch.
+
+Security-first directive section "API Security" requires rate limiting and throttling on all public endpoints with exponential backoff. ESO is a consumer of a rate-limited external API (1Password) and today implements none of those controls. This spec brings ESO into line with the house standard.
+
+## Requirements
+
+### Requirement 1: ExternalSecret refresh interval standardization
+
+**User Story:** As an operator, I want every ExternalSecret in the cluster to declare a refresh interval appropriate to the secret's sensitivity, so that the fleet's steady-state 1P read rate is predictable and known.
+
+#### Acceptance Criteria
+
+1. WHEN any ExternalSecret is authored or modified THEN it SHALL declare a non-zero `spec.refreshInterval`.
+2. WHEN the fleet is audited THEN the default refresh interval SHALL be 24h for all long-lived secrets (API keys, DB passwords, TLS certs that do not rotate on minutes).
+3. WHEN a secret has a real rotation SLO shorter than 24h THEN its ExternalSecret SHALL document the rotation reason in an inline comment and use the matching interval (e.g. 1h for short-lived tokens).
+4. WHEN the cluster is observed THEN the total projected 1P read rate from ExternalSecrets SHALL be under 100 reads/day at steady state, leaving 90% of the daily cap available for ad-hoc and ansible work.
+5. WHEN a new ExternalSecret is opened in a PR THEN CI SHALL fail if `spec.refreshInterval` is absent or set to `0`.
+
+### Requirement 2: ESO circuit breaker against an exhausted cap
+
+**User Story:** As an operator, I want ESO to stop calling `op` when the 1P daily cap is already exhausted, so that retries cannot extend the rate-limit window the way they did on 2026-04-18.
+
+#### Acceptance Criteria
+
+1. WHEN the metric `onepassword_ratelimit_remaining{type="account"}` is less than 10 THEN the ESO controller deployment SHALL be scaled to 0 replicas automatically.
+2. WHEN that metric recovers to at least 100 THEN the ESO controller deployment SHALL be scaled back to 1 replica automatically.
+3. WHEN the circuit breaker trips or recovers THEN a Discord alert SHALL fire with a LOTR theme so it is recognizable against the existing alert vocabulary.
+4. WHEN ArgoCD attempts to reconcile ESO during a trip THEN it SHALL NOT override the 0-replica state (i.e. the scaling is reconciled by a controller ArgoCD respects, or the ArgoCD Application ignores the `replicas` field).
+5. WHEN the cluster boots from cold and the metric is unavailable THEN the circuit breaker SHALL default to "closed" (ESO runs) rather than "open", so an outage of the collector cannot itself stop secret sync.
+
+### Requirement 3: ClusterSecretStore validation cost reduction
+
+**User Story:** As an operator, I want ESO's ClusterSecretStore health checks to not count as meaningful reads against the 1P cap, so that a large fleet of ExternalSecrets does not multiply validation cost.
+
+#### Acceptance Criteria
+
+1. WHEN the ClusterSecretStore is reconciled THEN it SHALL NOT issue an `op` vault-item call per reconcile loop merely to validate credentials.
+2. WHEN the ClusterSecretStore fails validation THEN it SHALL back off with exponential jitter up to a 1h cap, not retry every 7 minutes as observed on 2026-04-18.
+3. WHEN multiple ExternalSecrets reference the same store THEN the store SHALL be validated once per refresh window, not once per ExternalSecret.
+
+### Requirement 4: Scheduled drain window ("night mode")
+
+**User Story:** As an operator, I want ESO to do its daily refresh in a concentrated window rather than spreading per-ExternalSecret ticks across the clock, so that ad-hoc `op` usage during business hours has a predictable quota head-room.
+
+#### Acceptance Criteria
+
+1. WHEN the fleet is running at steady state THEN at least 80% of all ExternalSecret refreshes SHALL be scheduled during a single 1-hour window overnight local time (US/Pacific).
+2. WHEN new ExternalSecrets are added THEN they SHALL inherit the same window unless the PR explicitly justifies otherwise.
+3. WHEN the window fires THEN the `onepassword_ratelimit_used{type="account"}` metric SHALL visibly step up, providing a natural "heartbeat" observable on the Grafana panel.
+
+### Requirement 5: Documentation and runbook update
+
+**User Story:** As an on-call operator, I want the existing quota runbook updated to reflect the new automated controls, so that the manual "scale ESO to 0" step is retired and operators know which metric drives the circuit breaker.
+
+#### Acceptance Criteria
+
+1. WHEN the runbook `docs/runbooks/onepassword-quota.md` is updated THEN it SHALL remove the manual scale-to-0 instruction and replace it with circuit-breaker status verification.
+2. WHEN an operator is investigating an unexpected circuit-breaker trip THEN the runbook SHALL include the three-step diagnostic: confirm quota via `op service-account ratelimit`, inspect circuit-breaker state, inspect recent ExternalSecret errors.
+3. WHEN the spec ships THEN the project's `CLAUDE.md` (k8s-argocd) SHALL be updated to document the circuit-breaker contract so future agents do not try to manually scale ESO again.
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- The circuit breaker SHALL be implemented as a small, testable piece: either a ConfigMap-driven CronJob + kubectl scale, a KEDA ScaledObject consuming the Prometheus metric, or a purpose-built controller. Prefer the smallest solution that meets Requirement 2.
+- The circuit breaker SHALL live in `infrastructure/external-secrets/` alongside the existing ESO manifests, not in a new top-level path.
+- Alerting SHALL reuse the existing Discord webhook + LOTR theme catalog, no new routing.
+- Manifests SHALL be kustomize-native; no new Helm dependencies.
+
+### Performance
+
+- Circuit breaker reaction time SHALL be under 2 minutes from threshold crossing.
+- Alert firing delay SHALL be under 30 seconds.
+
+### Security
+
+- The circuit breaker SHALL NOT require a new 1P service-account token.
+- The metric scrape target SHALL be read-only Prometheus, no write path.
+- The Kubernetes ServiceAccount doing the scaling SHALL have least-privilege RBAC: `patch deployments/scale` in the `external-secrets` namespace only, no other verbs or namespaces.
+
+### Reliability
+
+- Default-closed: if the quota metric is unavailable for any reason, ESO SHALL continue to run. False positives (shutting off secrets during a monitoring outage) are worse than false negatives.
+- The circuit breaker SHALL emit a heartbeat metric so "breaker evaluated recently" is observable, independent of whether it tripped.
+
+### Usability
+
+- Tripping state SHALL be visible on the existing 1Password Grafana dashboard (new single-stat panel) without a separate dashboard.

--- a/.spec-workflow/specs/eso-rate-limit-hardening/tasks.md
+++ b/.spec-workflow/specs/eso-rate-limit-hardening/tasks.md
@@ -1,0 +1,93 @@
+# Tasks Document
+
+- [ ] 1. Audit current ExternalSecret refresh intervals across the cluster
+  - File: none (investigation), output recorded inline in this task comment once run
+  - Run `kubectl get externalsecrets -A -o json | jq '.items[] | {ns:.metadata.namespace, name:.metadata.name, refresh:.spec.refreshInterval}'`
+  - Compute projected daily reads: sum(86400 / refreshInterval_seconds) per secret; note anything under 24h
+  - Purpose: Establish the baseline fleet-wide read rate before changing anything
+  - _Leverage: existing 1P quota metrics on Grafana to cross-check observed vs projected_
+  - _Requirements: 1.4_
+
+- [ ] 2. Standardize refresh intervals to 24h with documented exceptions
+  - Files: `infrastructure/**/externalsecret.yaml`, `apps/**/externalsecret.yaml`
+  - Set `spec.refreshInterval: 24h` on every ExternalSecret unless rotation SLO dictates otherwise
+  - Add inline YAML comment for any non-24h value explaining why
+  - Purpose: Collapse fleet steady-state reads to ~1 per secret per day
+  - _Leverage: existing 1P feedback memory `feedback_eso_sync_after_1p_change.md` 24h precedent_
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [ ] 3. Stagger refresh times into an overnight window
+  - Files: `infrastructure/**/externalsecret.yaml`, `apps/**/externalsecret.yaml`
+  - Add `spec.refreshPolicy: Periodic` and `spec.refreshInterval: 24h` anchored so refreshes cluster into the 02:00-03:00 US/Pacific window (use a small spread per namespace to avoid a single-minute thundering herd)
+  - Note that ESO v2 may not support absolute schedule anchoring; if so, document the "best-effort distribution" alternative and keep the staggering loose
+  - Purpose: Concentrate reads in a known quiet window, produce a visible quota heartbeat
+  - _Leverage: ESO v2.1.0 docs (currently deployed image `ghcr.io/external-secrets/external-secrets:v2.1.0`)_
+  - _Requirements: 4.1, 4.2, 4.3_
+
+- [ ] 4. Add CI check that blocks ExternalSecrets missing refreshInterval
+  - File: `.github/workflows/externalsecret-lint.yml` (new) or extend the existing kustomize-build workflow
+  - Script: `yq` or `kustomize build | grep` over every ExternalSecret manifest, fail if `spec.refreshInterval` is absent, empty, or `0s`
+  - Purpose: Prevent regression via future PRs
+  - _Leverage: existing GitHub Actions in `.github/workflows/`_
+  - _Requirements: 1.5_
+
+- [ ] 5. Implement ESO circuit breaker (preferred path: CronJob + kubectl)
+  - Files:
+    - `infrastructure/external-secrets/circuit-breaker/cronjob.yaml` (new)
+    - `infrastructure/external-secrets/circuit-breaker/rbac.yaml` (new, ServiceAccount + Role + RoleBinding scoped to `external-secrets` namespace, verbs `get`/`patch` on `deployments/scale`)
+    - `infrastructure/external-secrets/circuit-breaker/script-configmap.yaml` (new, holds the trip/recover shell script)
+    - `infrastructure/external-secrets/kustomization.yaml` (update to include the directory)
+  - Schedule: every 2 minutes (`*/2 * * * *`)
+  - Logic: query Prometheus for `onepassword_ratelimit_remaining{type="account"}` via the in-cluster Prometheus service; if less than 10, `kubectl -n external-secrets scale deploy external-secrets --replicas=0`; if 100 or more and currently 0, scale to 1. Default-closed if metric is unavailable.
+  - Purpose: Automate the manual mitigation from the 2026-04-18 runbook
+  - _Leverage: existing kube-prometheus-stack service DNS name, existing Discord webhook pattern from monitoring alerts_
+  - _Requirements: 2.1, 2.2, 2.5, NFR security (RBAC scope)_
+
+- [ ] 6. Tell ArgoCD to ignore the ESO replicas field
+  - File: `bootstrap/apps/external-secrets.yaml` (or equivalent ArgoCD Application manifest for ESO)
+  - Add `spec.ignoreDifferences: [{group: apps, kind: Deployment, jsonPointers: ["/spec/replicas"]}]`
+  - Purpose: Let the circuit breaker win over ArgoCD reconciliation during a trip
+  - _Leverage: existing ArgoCD Application shape used for HA-managed workloads_
+  - _Requirements: 2.4_
+
+- [ ] 7. Add Discord alerts for circuit-breaker trips
+  - File: `infrastructure/monitoring/kube-prometheus-stack/values.yaml` (new alert rule group `eso-circuit-breaker`)
+  - Alerts:
+    - `ESOCircuitBreakerTripped` (critical, fires when ESO replicas=0 AND remaining<10)
+    - `ESOCircuitBreakerStuck` (warning, fires when replicas=0 AND remaining>=500 for 10m, indicates recovery logic bug)
+    - `ESOCircuitBreakerHeartbeatStale` (warning, fires if last_evaluation metric >10m old)
+  - Themed message: LOTR. Suggested: "The Beacons of Gondor are lit (ESO paused, quota exhausted)"
+  - Purpose: Visibility on automated trips
+  - _Leverage: existing PrometheusRule group `onepassword-quota` already shipped in this repo_
+  - _Requirements: 2.3, NFR usability_
+
+- [ ] 8. Add a circuit-breaker state panel to the 1P Grafana dashboard
+  - File: `infrastructure/monitoring/grafana-dashboards/grafana-dashboard-1password-quota.yaml`
+  - New single-stat panel, binary "ESO breaker: CLOSED/OPEN" driven off `kube_deployment_spec_replicas{namespace="external-secrets",deployment="external-secrets"}`
+  - Purpose: Operator sees breaker state at the same place they see quota
+  - _Leverage: existing dashboard panel shape_
+  - _Requirements: NFR usability_
+
+- [ ] 9. Investigate ClusterSecretStore validation cost
+  - File: none (investigation)
+  - Read ESO v2.1.0 source for the ClusterSecretStore health-check loop, confirm whether each reconcile does an `op` vault-item call or only a control-plane call
+  - If vault-item call: open upstream issue, file a follow-up task to downgrade to ConfigMap-driven token injection
+  - If control-plane only: note as not-a-real-cost, close Requirement 3 with a decision record
+  - Purpose: Validate or invalidate a key assumption from the 2026-04-18 incident
+  - _Leverage: ESO docs + source_
+  - _Requirements: 3.1_
+
+- [ ] 10. Update runbook and CLAUDE.md
+  - Files:
+    - `docs/runbooks/onepassword-quota.md` (update: remove manual scale-to-0, add circuit-breaker diagnostic)
+    - `CLAUDE.md` (k8s-argocd root, add a brief note: "ESO scaling is managed by the circuit breaker, do not kubectl scale manually")
+  - Purpose: Align written procedure with automated reality
+  - _Leverage: existing runbook_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 11. End-to-end smoke test
+  - Set up a synthetic condition: scrape a fake quota metric exposing `onepassword_ratelimit_remaining=5`, confirm CronJob trips ESO to 0 within 4 minutes, confirm alert fires, confirm Grafana panel flips to OPEN; flip metric back to 950, confirm recovery to 1 within 4 minutes
+  - Record results in PR description
+  - Purpose: Verify the feature actually works end-to-end before trusting it in production
+  - _Leverage: existing prometheus stack, node_exporter textfile collector pattern_
+  - _Requirements: all_

--- a/.spec-workflow/specs/media-secrets-declarative/requirements.md
+++ b/.spec-workflow/specs/media-secrets-declarative/requirements.md
@@ -1,0 +1,126 @@
+# Requirements Document
+
+## Introduction
+
+The media namespace apps (Jellyseerr, Sonarr, Radarr, Prowlarr, Jellyfin, Bazarr, NZBGet, qBittorrent) all store API keys, account credentials, and provider-identifying fields as plaintext inside runtime config files on the `k8s-nfs` RWX PVCs. None of it is managed in IaC.
+
+This spec closes that gap with one mechanism: every sensitive field is sourced from 1Password via ESO, then injected at pod startup via a small `jq` / `xmlstarlet` initContainer that merges the fields into the existing config file without clobbering UI-managed state. UI-editable settings (library mappings, user accounts, permissions) remain in the PVC and are not touched.
+
+**Scope boundary (what is "sensitive"):** Not just API keys. The `k8s-argocd` repo is public. The operator wants the presence of the downloader stack (Sonarr/Radarr/Prowlarr directories, image pulls) to be acceptable, but account identifiers, Usenet provider hostnames, indexer/tracker names, and any field that identifies which paid services are in use MUST NOT appear in Git, in rendered manifests, or in commit history. Concretely this covers: account usernames and email addresses, Usenet server hostnames (`news.example.com`, `eu.example.com`), server ports and SSL flags, account passwords and API keys, indexer display names and URLs (NZBgeek, Nzb.su, NzbPlanet, etc.), indexer API keys, tracker hostnames and cookies, RSS feed URLs containing tokens, download client auth.
+
+**What stays in Git:** App directory names, bjw-s/app-template Helm values (image pins, resources, probes), namespace manifests, Jellyfin playback config, PVC definitions, ArgoCD Applications. The operator accepts that "this cluster runs the *arr stack" is derivable from these. The line is drawn at "who I pay and what accounts I use."
+
+This is a direct execution of the homelab prime directive ("everything must be managed in code") applied to a surface that has been missed up to now. It ships after `eso-rate-limit-hardening` so the new ExternalSecret resources this adds cannot amplify a future rate-limit drain.
+
+## Alignment with Product Vision
+
+Prime directive ("everything managed in code, no manual configuration") + security-first directive ("never hardcode secrets... use secret managers"). Today the media stack stores API keys as cleartext on NFS. A NAS misconfiguration or a ransomware event on the volume leaks every key at once. Rotating a key means editing the config via each app's UI or by hand-editing the file, neither of which is IaC. This spec makes the rotation a single 1Password edit.
+
+This also closes a known debt line: the ansible-side secret discipline (`op-secret-cache`, kill switch, vault patterns) has no equivalent on the k8s side for per-app secrets beyond ExternalSecret-to-Secret. The initContainer merge pattern extends that discipline to apps that do not support env-based secret injection.
+
+## Requirements
+
+### Requirement 1: ExternalSecrets for every sensitive field in the media stack
+
+**User Story:** As an operator, I want every sensitive field across the media stack (API keys + provider/account identifiers + auth credentials) to exist as a 1Password item mirrored to a Kubernetes Secret, so that rotation is a single 1P edit and no such field ever lives in source, rendered manifests, or Git history.
+
+#### Acceptance Criteria
+
+1. WHEN the namespace is audited THEN every field matching the classification in the Introduction SHALL have a corresponding item in the `Infrastructure` 1Password vault. Minimum coverage at ship time: Jellyseerr own-API-key, Jellyfin API key, Sonarr API key, Radarr API key, Prowlarr API key, Bazarr API key, qBittorrent admin password, NZBGet control+add credentials, every Prowlarr indexer (name + URL + API key) stored together as a single JSON-blob 1P item, every Usenet provider server config (host + port + SSL + username + password) as one or more 1P items per provider.
+2. WHEN the cluster is reconciled THEN one ExternalSecret per app SHALL exist mapping those 1P items into namespace-local Secrets. The ESO `remoteRef` SHALL use the `<item-id>/<field>` format documented in the root `CLAUDE.md`, not the `op://` URI style.
+3. WHEN a 1P item is rotated THEN a manual ESO sync (per the existing operator feedback) SHALL propagate the new value within 60 seconds.
+4. WHEN the spec ships THEN every sensitive field currently living in a config file SHALL be rotated once at cut-over (treat the pre-spec cleartext value as compromised).
+5. WHEN new sensitive fields are added in the future (new indexer, new provider, new inter-app credential) THEN the pattern SHALL be extended by adding 1P items and updating the ExternalSecret allow-list, not by writing to config files.
+6. WHEN `git grep` is run across the repo and its history after cut-over THEN it SHALL return zero hits for any Usenet provider hostname, any indexer display name present in Prowlarr, any account email/username, and any non-Kubernetes-internal URL in a downloader config. CI SHALL enforce this with a block-list gate on PRs.
+
+### Requirement 2: initContainer merges secrets into config on every start
+
+**User Story:** As the Jellyseerr pod (and Sonarr, Radarr, etc.), I need the secret fields in my config file to come from a Kubernetes Secret on every startup, so that UI-editable fields can still be managed via the app but credential fields remain authoritative in IaC.
+
+#### Acceptance Criteria
+
+1. WHEN a pod starts THEN an initContainer SHALL read the namespace-local Secret at `/secrets` and merge the relevant fields into the config file at `/config` using `jq` for JSON or `xmlstarlet` for XML.
+2. WHEN the config file does not exist yet (first install) THEN the initContainer SHALL NOT create one; the main container runs the first-time setup wizard, and the merge only activates on subsequent starts.
+3. WHEN the initContainer cannot produce a valid merged file (jq error, secret missing) THEN it SHALL exit non-zero so the main container never starts with a partially-merged file.
+4. WHEN the merge completes THEN the only fields written SHALL be those listed in the per-app allow-list in the ConfigMap; all other fields in the config file SHALL be preserved byte-for-byte.
+5. WHEN the merge runs THEN it SHALL take a dated backup of the pre-merge config file (e.g. `settings.json.pre-merge.<timestamp>`) kept for 7 days, so a bad merge is reversible.
+
+### Requirement 3: Alignment with the rate-limit hardening spec
+
+**User Story:** As an operator, I want the new ExternalSecrets added by this spec to honor the fleet-wide refresh-interval standards set in `eso-rate-limit-hardening`, so that rolling this out cannot itself create an incident.
+
+#### Acceptance Criteria
+
+1. WHEN any new ExternalSecret is authored by this spec THEN it SHALL declare `spec.refreshInterval: 24h`.
+2. WHEN this spec is ready to ship THEN `eso-rate-limit-hardening` SHALL already be merged and its circuit breaker SHALL be operational in the cluster.
+3. WHEN the additional ExternalSecrets are added THEN the projected steady-state read rate increase SHALL be documented in the PR body (scope widened from ~7 to ~12-15 secrets at 1 read/day each; confirm exact count in task 1 audit).
+
+### Requirement 3b: Prowlarr indexer list handled as a single encrypted blob
+
+**User Story:** As an operator, I want Prowlarr's entire indexer list (N indexers × {name, URL, API key, categories, priority}) to be sourced from a single 1P item at startup, so that the public repo never names any indexer and operators do not need to maintain N separate ExternalSecrets.
+
+#### Acceptance Criteria
+
+1. WHEN Prowlarr starts THEN its initContainer SHALL read a JSON blob from a Kubernetes Secret and POST each entry to the Prowlarr REST API (`/api/v1/indexer`) after Prowlarr's main container is healthy.
+2. WHEN the blob is absent or empty THEN Prowlarr SHALL start normally with whatever indexers already exist in its SQLite DB; the sync is additive-idempotent, not authoritative.
+3. WHEN an indexer is removed from the 1P blob THEN an operator-initiated cleanup command (documented in the runbook) SHALL be used to delete it from Prowlarr; automatic deletion is out of scope because it risks removing hand-tuned local settings.
+4. WHEN Sonarr and Radarr query Prowlarr for their indexer feeds THEN they SHALL continue to use Prowlarr's built-in apps-sync (no independent indexer list maintained in Sonarr/Radarr configs).
+
+### Requirement 4: Per-app secret inventory
+
+**User Story:** As an operator, I want a single document that lists which secrets each media app consumes and which 1P item each maps to, so that auditing and rotation are straightforward.
+
+#### Acceptance Criteria
+
+1. WHEN this spec ships THEN `docs/runbooks/media-secrets-inventory.md` SHALL exist with one table row per (app, secret field, 1P item, Kubernetes Secret key).
+2. WHEN a rotation is performed THEN the runbook SHALL describe the exact steps in order (edit 1P, kick ESO sync, delete pod, confirm new key via API smoke-test).
+3. WHEN a new app is added THEN the PR adding it SHALL add a row to this table as part of the same PR, not a follow-up.
+
+### Requirement 5: Readiness to generalize to a reusable component
+
+**User Story:** As an operator, I want the initContainer pattern to be reusable so that adding it to Radarr, Sonarr, and any future app is a small diff, not a copy-paste of 150 lines.
+
+#### Acceptance Criteria
+
+1. WHEN the initContainer is implemented for Jellyseerr THEN its shell script SHALL be held in a per-app ConfigMap (not inlined in values.yaml) so the values file stays clean.
+2. WHEN the same pattern is applied to a second app (Sonarr) THEN it SHALL reuse the same Kustomize component or bespoke-chart helper (TBD during design phase), with only the app-specific allow-list differing.
+3. WHEN the pattern is documented in `docs/patterns/secret-injection-initcontainer.md` THEN a new operator SHALL be able to apply it to another app in under 30 minutes.
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- The merge script SHALL be a single shell function per file format (one for JSON, one for XML), kept under 40 lines each, vendored into every app's ConfigMap.
+- The initContainer image SHALL be a pinned-by-digest image with `jq`, `xmlstarlet`, and `coreutils` only. Prefer `alpine/git`-style minimal images over bespoke.
+- No new Helm charts. Extend existing bjw-s `app-template` values via `initContainers` and `configMaps`.
+- No new CustomResourceDefinitions.
+
+### Performance
+
+- Merge completes in under 2 seconds per pod start.
+- The initContainer SHALL NOT touch the network (no API calls, no DNS lookups beyond what the image needs for startup).
+
+### Security
+
+- The initContainer SHALL run as non-root with `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false` unless the existing main container runs as root (Jellyseerr currently does, see `apps/media/jellyseer/values.yaml`).
+- The mounted Secret SHALL be read-only.
+- The config file SHALL remain owned by the main container's runtime UID after the merge.
+- Pre-merge backups SHALL be pruned after 7 days to limit the blast radius of a stolen NFS volume.
+- All new Secrets SHALL have `type: Opaque` and SHALL NOT set `stringData` in source (ExternalSecret handles the encoding).
+- Rendered manifests generated by `make all` SHALL be scanned in CI for provider hostnames and account identifiers before commit (see Requirement 1 criterion 6). A leaked provider name in a rendered Kustomize output is as bad as a leaked value in the source chart.
+- The pre-merge backup files (`settings.json.pre-merge.<timestamp>`) live on the NFS PVC and contain the unsanitized config. The 7-day retention and NFS-level ZFS snapshot policy together bound the exposure window.
+
+### Operational constraints
+
+- During cut-over, *arr apps MUST be restarted via the `scale 0 -> sleep 5 -> scale 1` pattern documented in the root `CLAUDE.md`, NOT via `kubectl rollout restart`. The `Recreate` strategy plus NFS file locks make rollout restart unsafe and have caused a SQLite corruption incident on 2026-03-15.
+- The rendered output of `make all` MUST be committed along with values changes; the repo does not deploy Helm releases directly, ArgoCD reads the flat manifests.
+
+### Reliability
+
+- If the initContainer fails, the main container SHALL NOT start, to avoid a partially-merged file being persisted to disk.
+- A restart of the main container SHALL re-run the initContainer; the merge SHALL be idempotent (running it twice on the same inputs produces the same output).
+
+### Usability
+
+- Operator runbook (Requirement 4) SHALL be accessible from the existing runbook index.
+- Rotating a single key SHALL not require a spec-workflow-level change; it is an operational action documented in the runbook.

--- a/.spec-workflow/specs/media-secrets-declarative/tasks.md
+++ b/.spec-workflow/specs/media-secrets-declarative/tasks.md
@@ -1,0 +1,136 @@
+# Tasks Document
+
+Order: tasks 1-2 audit the current state, tasks 3-5 ship Jellyseerr as the prototype, tasks 6-8 extend to Sonarr/Radarr/Prowlarr/Bazarr/NZBGet/qBittorrent, task 9 generalizes, task 10 smoke-tests, task 11 closes the public-repo leak gate.
+
+- [ ] 1. Inventory every sensitive field currently stored in a media-namespace config file
+  - File: none (investigation). Output captured inline in task comment and mirrored into `docs/runbooks/media-secrets-inventory.md` draft.
+  - Scope is broader than "API keys": cover every field matching the classification in `requirements.md` (account usernames/emails, Usenet server hostnames + ports + SSL flags, account passwords, API keys, indexer display names + URLs + keys, tracker cookies, RSS feed URLs with tokens, download client auth).
+  - Apps in scope: Jellyseerr (`/app/config/settings.json`), Sonarr (`/config/config.xml`), Radarr (`/config/config.xml`), Prowlarr (`/config/config.xml` + indexer table in `prowlarr.db`), Bazarr (`/config/config/config.ini` + `config.yaml`), NZBGet (`/config/nzbget.conf`), qBittorrent (`/config/qBittorrent/qBittorrent.conf`), Jellyfin (only API keys/users).
+  - For each field, note: app, file path, JSON/XML/INI path, current value (to be rotated), suggested 1P item name, classification (API key / account / provider hostname / indexer / tracker / other).
+  - For Prowlarr specifically: dump the full indexer list via the API (`GET /api/v1/indexer`) and capture name+URL+key+categories per entry; this becomes the JSON blob for Requirement 3b.
+  - Purpose: Ground-truth the expanded scope before writing any manifests.
+  - _Leverage: `kubectl exec` + the Sonarr/Radarr/Prowlarr REST APIs for live state_
+  - _Requirements: 1.1, 3b.1, 4.1_
+
+- [ ] 2. Rotate every inventoried key in 1Password and create the 1P items
+  - File: 1Password `Infrastructure` vault (out of repo), using write-capable token `~/.op_service_account_token`.
+  - For every field from task 1, either reuse an existing 1P item (e.g. `jellyfin-api`) or create a new one. Rotate the value at creation time. Treat the old cleartext value as leaked.
+  - Purpose: Stop the current secrets from being authoritative before the merge machinery exists.
+  - _Leverage: `reference_1password_tokens.md` for the write-capable token location_
+  - _Requirements: 1.1, 1.4_
+
+- [ ] 3. Create the Jellyseerr ExternalSecret and merge-script ConfigMap
+  - Files:
+    - `apps/media/jellyseer/externalsecret.yaml` (new; pulls jellyseerr-api, jellyseerr-vapid, jellyseerr-client-id, jellyfin-api, sonarr-api, radarr-api into one Secret `jellyseerr-secrets`)
+    - `apps/media/jellyseer/merge-script-configmap.yaml` (new; holds `merge.sh` which takes `/secrets/*` + `/config/settings.json` and writes merged settings.json)
+    - `apps/media/jellyseer/kustomization.yaml` (update to include the two new files)
+  - The merge script: bail out if `/config/settings.json` does not exist (first install); otherwise read each secret file, `jq --arg ... 'setpath([...])'` for each field, write atomically.
+  - `spec.refreshInterval: 24h` on the ExternalSecret.
+  - Purpose: The 1P → Secret pipeline and the logic that will use it.
+  - _Leverage: existing `externalsecret.yaml` patterns in `apps/dashboard/homepage/`_
+  - _Requirements: 1.2, 2.1, 2.4, 3.1_
+
+- [ ] 4. Wire the initContainer into Jellyseerr values.yaml
+  - File: `apps/media/jellyseer/values.yaml`
+  - Add `controllers.main.initContainers.secrets-merge` with:
+    - Image: `ghcr.io/alpine/alpine:3.20` (or an image with `jq` prebuilt; pin by digest per `pin-media-images` convention)
+    - Command: `sh /scripts/merge.sh`
+    - Mounts: `/config` from the existing PVC, `/secrets` from `jellyseerr-secrets`, `/scripts` from the merge-script ConfigMap
+    - Security context: non-root when feasible; falls back to match main container UID so the merged file stays readable
+    - Resource requests/limits appropriate for a 2-second task
+  - Purpose: Actually run the merge before main container starts.
+  - _Leverage: bjw-s `app-template` initContainers schema already used elsewhere if present, otherwise the raw pod-template spec_
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+
+- [ ] 5. Cut-over and validate Jellyseerr
+  - File: none (operational)
+  - Before deploy: take a backup of the existing `/app/config/settings.json` from inside the pod.
+  - Deploy. Exec into the pod. Confirm the merged settings.json has the new rotated values in the expected JSON paths and that every non-secret field (libraries, permissions, user records) is preserved byte-for-byte (diff against backup).
+  - Smoke test: open a request in Jellyseerr, verify it propagates to Sonarr (proves sonarr apiKey works). Open a Jellyfin-login test (proves jellyfin apiKey works).
+  - Purpose: Prove the Jellyseerr prototype works end-to-end before extending to other apps.
+  - _Leverage: existing Jellyseerr → Sonarr integration test flow_
+  - _Requirements: all Jellyseerr-related_
+
+- [ ] 6. Extend to Sonarr (config.xml)
+  - Files:
+    - `apps/media/sonarr/externalsecret.yaml` (new)
+    - `apps/media/sonarr/merge-script-configmap.yaml` (new; XML merge via `xmlstarlet ed -u '/Config/ApiKey' -v ...`)
+    - `apps/media/sonarr/values.yaml` (add initContainer)
+    - `apps/media/sonarr/kustomization.yaml` (update)
+  - Purpose: Apply the same pattern to the XML-config case
+  - _Leverage: task 3-4 as the template_
+  - _Requirements: 5.2 (pattern reuse)_
+
+- [ ] 7. Extend to Radarr
+  - Files mirror task 6 under `apps/media/radarr/`
+  - Purpose: Same
+  - _Leverage: task 6_
+  - _Requirements: 5.2_
+
+- [ ] 8a. Extend to Prowlarr (API key merge + indexer blob sync)
+  - Files mirror tasks 6/7 under `apps/media/prowlarr/` for the `config.xml` API key merge.
+  - Additional file: `apps/media/prowlarr/indexer-sync-job.yaml` (new). A post-start Job (NOT an initContainer, since Prowlarr's API is needed) that reads the indexer JSON blob from `/secrets/indexers.json` and POSTs each entry to `http://localhost:8989/api/v1/indexer` with the Prowlarr API key. Runs on pod start via a lifecycle hook or a small sidecar.
+  - The JSON blob itself is populated via task 1's Prowlarr inventory, sanitized for tokens, committed to 1P as a single item (field name `indexers_json`).
+  - Purpose: Cover Requirement 3b. Prowlarr is the only app where the sensitive data is a list-of-objects, not a scalar field.
+  - _Leverage: Prowlarr REST API, tasks 6/7 for the scalar fields_
+  - _Requirements: 1.1, 3b.1, 3b.2, 3b.4_
+
+- [ ] 8b. Extend to NZBGet (Usenet provider + control credentials)
+  - Files under `apps/media/nzbget/`: ExternalSecret + merge-script ConfigMap + values.yaml initContainer.
+  - INI-format merge (nzbget.conf is key=value). Merge: `Server1.Host`, `Server1.Port`, `Server1.Username`, `Server1.Password`, `Server1.Encryption`, plus `ControlUsername`, `ControlPassword`, `AddUsername`, `AddPassword`, `RestrictedUsername`, `RestrictedPassword`. Use `sed -i` or `crudini` for INI edits; script kept under 40 lines as per NFR.
+  - Purpose: Keep every provider host/credential out of Git.
+  - _Leverage: tasks 6/7 as the template_
+  - _Requirements: 1.1, 5.2_
+
+- [ ] 8c. Extend to qBittorrent (WebUI auth + optional tracker auth)
+  - Files under `apps/media/qbittorrent/`: ExternalSecret + merge-script ConfigMap + values.yaml initContainer.
+  - Merge the `WebUI\\Password_PBKDF2` line and `WebUI\\Username` in `qBittorrent.conf` plus any categories containing tracker cookies (likely in `BT_backup/categories.json` if present).
+  - Purpose: Close the downloader-auth gap.
+  - _Leverage: tasks 6/7_
+  - _Requirements: 1.1, 5.2_
+
+- [ ] 8d. Extend to Bazarr (provider API keys)
+  - Files under `apps/media/bazarr/`: ExternalSecret + merge-script ConfigMap + values.yaml initContainer.
+  - INI/YAML merge for `config.ini` / `config.yaml`: provider API keys (OpenSubtitles credentials, Subscene, etc.) plus the Bazarr own API key.
+  - Purpose: Same-shape coverage for the subtitle side of the stack.
+  - _Leverage: tasks 6/7_
+  - _Requirements: 1.1, 5.2_
+
+- [ ] 9. Generalize the pattern into a reusable Kustomize component
+  - File: `infrastructure/components/secret-merge-initcontainer/` (new)
+    - `kustomization.yaml` declaring it a component
+    - `initcontainer-patch.yaml` template snippet
+    - `README.md` documenting how to consume it (secret name + merge-script ConfigMap name as variables)
+  - Refactor Jellyseerr / Sonarr / Radarr / Prowlarr to consume the component, reducing each app's diff to just the per-app ExternalSecret and merge-script ConfigMap.
+  - Purpose: Reduce the per-app cost to "add the secret, add the merge script, consume the component".
+  - _Leverage: Kustomize components (already used if present in the repo; otherwise introduce them here)_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 10. Document, runbook, and smoke-test
+  - Files:
+    - `docs/runbooks/media-secrets-inventory.md` (finalize from task 1 draft, include the full field classification, not just API keys)
+    - `docs/patterns/secret-injection-initcontainer.md` (new, covers the how/why, when to pick this pattern vs env-based secret injection, and the Prowlarr Job-based variant for list-of-objects)
+  - Smoke test: for each app, rotate a sensitive 1P item, kick ESO sync, `kubectl scale deploy <name> -n media --replicas=0 && sleep 5 && kubectl scale deploy <name> -n media --replicas=1` (per `CLAUDE.md` operational warning), confirm new value is in the merged config, confirm the app still starts and functions.
+  - Purpose: Hand-off documentation and production-readiness confidence
+  - _Leverage: existing `docs/runbooks/` structure_
+  - _Requirements: 4.1, 4.2, 5.3_
+
+- [ ] 11. Public-repo leak gate (the "don't advertise my accounts" guardrail)
+  - File: `.github/workflows/leak-scan.yml` (new)
+  - CI action that runs on every PR against main and fails the build if any of the following are found in changed files OR the full rendered output from `make all` in `apps/media/`:
+    - Known Usenet provider substrings (maintained as a block-list in `scripts/ci/provider-blocklist.txt`, not committed with real values but populated from the 1P inventory at CI time via a masked secret, or hashed for offline comparison).
+    - Any email address matching `*@*` (with an allow-list for known-safe docs addresses).
+    - Any hostname matching common Usenet TLD patterns (e.g. hosts under `.net` or `.com` inside `apps/media/nzbget/` rendered output, excluding the cluster-internal `*.svc.cluster.local`).
+    - Tracker-style patterns (domain containing `tracker`, `torrent`, or `anounce`).
+  - On block, emit a human-readable diff pointer so the author can see which file/line tripped it.
+  - Purpose: Prevent an accidental future PR from putting the "who I pay" signal into Git. Paired with Requirement 1 criterion 6.
+  - _Leverage: existing `.github/workflows/` patterns, pre-commit / `gitleaks` conventions_
+  - _Requirements: 1.6_
+
+- [ ] 12. History audit (one-shot, no scrub)
+  - File: none (investigation). Output recorded in the PR body or an operator note, not a committed doc (to avoid a committed doc being the leak vector itself).
+  - Run `git log --all -p | grep -iE '<provider-hostnames from 1P inventory>'` over the full k8s-argocd history. If hits found, decide on a case-by-case basis whether to `git filter-repo` (with the usual "this breaks forks" warning) or rotate-and-accept.
+  - Currently believed clean based on the 2026-04-22 surface audit that preceded this spec; this task just confirms.
+  - Purpose: Close the "maybe it leaked in the past" question one time.
+  - _Leverage: `git log`, `git filter-repo` if needed_
+  - _Requirements: 1.6 (retrospective)_

--- a/infrastructure/monitoring/loki/Chart.lock
+++ b/infrastructure/monitoring/loki/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: loki
+  repository: https://grafana.github.io/helm-charts
+  version: 6.27.0
+digest: sha256:6e2eb3e3aba7dd4f70f27d78a1a7d63ffeb1762c3149be87c9e1dcdc2bf8e9b6
+generated: "2026-04-27T16:08:07.56908913Z"


### PR DESCRIPTION
Track two in-progress spec-workflow specs (eso-rate-limit-hardening, media-secrets-declarative) and the Loki Helm Chart.lock for reproducible dependency pinning. Also gitignore the local-only .mcp.json so it stays out of the repo.